### PR TITLE
Keywords added in OSPEX when reading L1 files

### DIFF
--- a/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
@@ -1,5 +1,5 @@
 pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fits_path_bk, time_shift = time_shift, energy_shift = energy_shift, distance = distance, $
-  flare_location= flare_location, elut_filename = elut_filename, demo = demo, ospex_obj = ospex_obj
+  flare_location= flare_location, elut_filename = elut_filename, demo = demo, ospex_obj = ospex_obj, det_ind = det_ind, pix_ind = pix_ind, shift_duration = shift_duration
 
   if keyword_set(demo) then begin
 
@@ -36,14 +36,15 @@ pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fit
   g03_10=[g03,g04,g05,g06,g07,g08,g09,g10]
 
   mask_use_detectors = intarr(32)
-  mask_use_detectors[g03_10] = 1
+  if not keyword_set(det_ind) then mask_use_detectors[g03_10] = 1 else mask_use_detectors[det_ind] = 1
 
   mask_use_pixels = intarr(12)
-  mask_use_pixels[*] = 1
+  if not keyword_set(pix_ind) then mask_use_pixels[*] = 1 else mask_use_pixels[pix_ind] = 1
 
 
   stx_read_pixel_data_fits_file, fits_path_data, time_shift, primary_header = primary_header, data_str = data_str, data_header = data_header, control_str = control_str, $
-    control_header= control_header, energy_str = energy_str, energy_header = energy_header, t_axis = t_axis, energy_shift = energy_shift,  e_axis = e_axis , use_discriminators = 0
+    control_header= control_header, energy_str = energy_str, energy_header = energy_header, t_axis = t_axis, energy_shift = energy_shift,  e_axis = e_axis , use_discriminators = 0, $
+    shift_duration = shift_duration
 
   data_level = 1
 

--- a/stix/idl/processing/spectrogram/stx_read_pixel_data_fits_file.pro
+++ b/stix/idl/processing/spectrogram/stx_read_pixel_data_fits_file.pro
@@ -1,6 +1,6 @@
 pro stx_read_pixel_data_fits_file, fits_path, time_shift, alpha=alpha, primary_header = primary_header, data_str = data, data_header = data_header, control_str = control, $
   control_header= control_header, energy_str = energy, energy_header = energy_header, t_axis = t_axis, e_axis = e_axis, $
-  energy_shift = energy_shift, use_discriminators = use_discriminators
+  energy_shift = energy_shift, use_discriminators = use_discriminators, shift_duration = shift_duration
 
   default, alpha, 0
   default, time_shift, 0
@@ -40,6 +40,22 @@ pro stx_read_pixel_data_fits_file, fits_path, time_shift, alpha=alpha, primary_h
   t_axis.time_end = t_end
   t_axis.DURATION = data.timedel
 
+  ; ************************************
+  ; Andrea (19-Jan-2022)
+  if keyword_set(shift_duration) then begin
+    ; Extract the time duration array
+    time_duration = data.timedel
+
+    ; Create temporary array
+    time_duration_shifted = time_duration
+
+    ; Perform the shift to the temporary array
+    time_duration_shifted[1:-1] = time_duration[0:-2]
+
+    ; Overwrite this information in the stx_time_axis
+    t_axis.DURATION = time_duration_shifted
+  endif
+  ; ************************************
 
   if control.energy_bin_mask[0] || control.energy_bin_mask[-1] and ~keyword_set(use_discriminators) then begin
 


### PR DESCRIPTION
Hi All,

I have made a few modifications in some of the Ewan's OSPEX procedures. First of all, I have added the keywords det_ind and pix_ind (in stx_convert_pixel_data.pro) so that the user can define which pixels and detectors to pass to OSPEX. Secondly, always for OSPEX, I implemented also the keyword shift_duration that allows to correct for the shift in the time duration array when reading L1 files (in  stx_read_pixel_data_fits_file.pro).

All the best,
Andrea