### PR TITLE
Temporary fix: OSPEX fitting with the BKG det avoiding attenuation

### DIFF
--- a/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
@@ -62,7 +62,7 @@
 ;                               
 ;-
 pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fits_path_bk, time_shift = time_shift, energy_shift = energy_shift, distance = distance, $
-  flare_location= flare_location, ospex_obj = ospex_obj, det_ind = det_ind, pix_ind = pix_ind, shift_duration = shift_duration
+  flare_location= flare_location, ospex_obj = ospex_obj, det_ind = det_ind, pix_ind = pix_ind, shift_duration = shift_duration, no_attenuation=no_attenuation
 
   if n_elements(time_shift) eq 0 then begin
     message, 'Time shift value not set using default value of 0 [s].', /info
@@ -209,6 +209,22 @@ pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fit
   ut_rcr = stx_time2any(t_axis.time_end)
 
   find_changes, rcr, index, state, count=count
+
+  ; ************************************************************
+  ; ******************** TEMPORARY FIX *************************
+  ; ***** Andrea: 2022-April-05
+  ; Temporarily creation of the no_attenuation keyword in order
+  ; to avoid attenuation of the fitted curve. This is useful for 
+  ; obtaining thermal fit parameters with the BKG detector in the 
+  ; case the attenuator is inserted. We tested it with the X 
+  ; class flare on 2021-Oct-26 and it works nicely.
+  if keyword_set(no_attenuation) then begin
+    rcr = rcr*0.
+    index = 0
+    state = 0
+  endif
+  ; ************************************************************
+  ; ************************************************************
 
   ;add the rcr information to a specpar structure so it can be incuded in the spectrum FITS file
   specpar = { sp_atten_state :  {time:ut_rcr[index], state:state} }


### PR DESCRIPTION
Hi All,

As discussed with Ewan, this pull request contains a temporary fix allowing to perform OSPEX fitting with the BKG detector without attenuating the fitted curve. We wanted to have this in order to deduce the single thermal fit parameters during times in which the attenuator is inserted. We showed that this method works nicely with the 2021-Oct-26 X-class flare. Now, we have other events for which we can test it.

Anyway, I called it "temporary fix" since we should also include other stuff, like adapting the detector area and so.

Best,
Andrea