### PR TITLE
Updated livetime correction based on discussions in March 2022

### DIFF
--- a/stix/idl/processing/livetime/stx_pileup_corr_parameter.pro
+++ b/stix/idl/processing/livetime/stx_pileup_corr_parameter.pro
@@ -7,9 +7,10 @@
 ;       stx_pileup_corr_parameter
 ;
 ; :description:
-;    This function estimates the fractional area of a single large pixel compared with the rest of the detector 
-;    group. It can be used in estimatiming the probablity that two photons hit a given large pixel and a different
-;    pixel in the same group resuling in anti-coincidence rejection (if different) or pileup (if the same).
+; This function estimates the fractional area of a single large pixel compared with the rest of the detector
+; group. It can be used in estimating the probability that when two photons are detected in the same group if
+; the first hits a given large pixel that the second hits different pixel resulting in anti-coincidence rejection.
+; Otherwise if both hit the same pixel pileup will occur.
 ;    Limitiations: This assumes uniform illumination over the detector pair 
 ;    This ignores the possiblity of the first hit being a small pixel 
 ;    

--- a/stix/idl/processing/livetime/stx_pileup_corr_parameter.pro
+++ b/stix/idl/processing/livetime/stx_pileup_corr_parameter.pro
@@ -1,0 +1,40 @@
+;---------------------------------------------------------------------------
+;+
+; :project:
+;       STIX
+;
+; :name:
+;       stx_pileup_corr_parameter
+;
+; :description:
+;    This function estimates the fractional area of a single large pixel compared with the rest of the detector 
+;    group. It can be used in estimatiming the probablity that two photons hit a given large pixel and a different
+;    pixel in the same group resuling in anti-coincidence rejection (if different) or pileup (if the same).
+;    Limitiations: This assumes uniform illumination over the detector pair 
+;    This ignores the possiblity of the first hit being a small pixel 
+;    
+;    
+; :categories:
+;    livetime, spectroscopy, imaging 
+;
+; :returns:
+;    scaler parameter to be used in livetime calulation e.g. by stx_livetime_fraction.pro
+;
+; :examples:
+;    beta = stx_pileup_corr_parameter()
+;
+; :history:
+;    21-Apr-2022 - ECMD (Graz), initial release
+;
+;-
+function stx_pileup_corr_parameter
+
+subc_str = stx_construct_subcollimator()
+pixel_areas = subc_str.det.pixel.area
+detector_area = (subc_str.det.area)[0]
+big_pixel_fraction = pixel_areas[0]/detector_area
+prob_diff_pix = (2./big_pixel_fraction - 1.)/(2./big_pixel_fraction)
+
+return, prob_diff_pix
+
+end


### PR DESCRIPTION
Now using:
tau = 10.1 microseconds readout time per event
eta = 2.63 microseconds latency time per event