### PR TITLE
stx_ospex_spectroscopy_demo & stx_imaging_demo - allow user to specif…

### DIFF
--- a/stix/idl/demo/stx_imaging_demo.pro
+++ b/stix/idl/demo/stx_imaging_demo.pro
@@ -16,14 +16,15 @@
 ; :history:
 ;   02-september-2021, Massa P., first release
 ;   23-august-2022, Massa P., made compatible with the up-to-date imaging sofwtare
+;   11-september-2023 - ECMD (Graz), allow user to specify output directory
+;
 ;
 ;-
 
 ;;******************************** LOAD DATA - June 7 2020, 21:41 UT ********************************
 
 ; Folder in which the files downloaded for this demonstration are stored
-out_dir = concat_dir( getenv('STX_DEMO_DATA'),'imaging', /d)
-
+ default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'imaging', /d)
 
 ; URL of the STIX data center
 website_url = 'https://datacenter.stix.i4ds.net/download/fits/bsd/'

--- a/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
+++ b/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
@@ -18,13 +18,18 @@
 ;
 ; :categories:
 ;    demo, spectroscopy
-;
+;    
+; :keywords:
+;    out_dir : in, type="string", default="concat_dir( getenv('STX_DEMO_DATA'),'ospex', /d)"
+;              a path to an output directroy where downloaded data can be saved 
+;               
 ; :history:
 ;   03-Mar-2022 - ECMD (Graz), initial release
 ;   16-Mar-2023 - ECMD (Graz), updated to use release version L1 files
+;   11-Sep-2023 - ECMD (Graz), allow user to specify output directory 
 ;
 ;-
-pro stx_ospex_spectroscopy_demo
+pro stx_ospex_spectroscopy_demo, out_dir = out_dir
 
   ;*********************************************** 1- AQUIRE DATA ******************************************************
 
@@ -33,7 +38,7 @@ pro stx_ospex_spectroscopy_demo
   site = 'http://dataarchive.stix.i4ds.net/fits/L1/2022/02/'
   
   ;The OSPEX folder in under stx_demo_data will usually start off empty on initial installation of the STIX software
-  out_dir = concat_dir( getenv('STX_DEMO_DATA'),'ospex', /d)
+  default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'ospex', /d)
 
   ;if the OSPEX demo database folder is not present then create it
   if ~file_test(out_dir, /directory) then begin


### PR DESCRIPTION
…y output directory

The input keyword out_dir has been added for the case where the user does not have write access to /ssw/so/stix/dbase/demo. Resolves #142 