### PR TITLE
Remove unused keyword from structure

### DIFF
--- a/stix/idl/demo/stx_imaging_demo.pro
+++ b/stix/idl/demo/stx_imaging_demo.pro
@@ -17,7 +17,7 @@
 ;   02-september-2021, Massa P., first release
 ;   23-august-2022, Massa P., made compatible with the up-to-date imaging sofwtare
 ;   11-september-2023 - ECMD (Graz), allow user to specify output directory
-;
+;   11-january-2024 - Massa P., use 'stx_get_science_fits_file' and 'stx_get_ephemeris_file' to download fits files
 ;
 ;-
 
@@ -26,28 +26,13 @@
 ; Folder in which the files downloaded for this demonstration are stored
  default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'imaging', /d)
 
-; URL of the STIX data center
-website_url = 'https://datacenter.stix.i4ds.net/download/fits/bsd/'
-
 ; UID of the science fits file to be dowloaded from the website
 uid_sci_file = "1178428688"
-; Download the science fits file (if not already stored in out_dir)
-sock_copy, website_url + uid_sci_file, out_name, status = status, out_dir = out_dir, $
-           local_file=path_sci_file, clobber=0
+path_sci_file = stx_get_science_fits_file(uid_sci_file, out_dir=out_dir)
 
-; UID of the background fits file to be dowloaded from the website           
+; UID of the background fits file to be dowloaded from the website 
 uid_bkg_file = "1178082832"
-; Download the background fits file (if not already stored in out_dir)
-sock_copy, website_url + uid_bkg_file, out_name, status = status, out_dir = out_dir, $
-           local_file=path_bkg_file, clobber=0
-
-; URL of the server containing the L2 auxiliary fits files
-website_url = 'http://dataarchive.stix.i4ds.net/fits/L2/'
-; Filename of the auxiliary L2 fits file to be downloaded
-file_name    = '2020/06/07/AUX/solo_L2_stix-aux-ephemeris_20200607_V01.fits'
-; Download the L2 auxiliary fits file (if not already stored in out_dir)
-sock_copy, website_url + file_name, out_name, status = status, out_dir = out_dir, $
-           local_file=aux_fits_file, clobber=0
+path_bkg_file = stx_get_science_fits_file(uid_bkg_file, out_dir=out_dir)
 
 stop
 
@@ -59,6 +44,12 @@ time_range    = ['7-Jun-2020 21:39:00', '7-Jun-2020 21:42:49']
 energy_range  = [6,10]
 
 stop
+
+;********************************* DOWNLOAD L2 EPHEMERIS FITS FILE ***********************************
+
+; This file is used for creating a structure with auxiliary data to use for image reconstruction 
+; (see next section)
+aux_fits_file = stx_get_ephemeris_file(time_range[0], time_range[1], out_dir=out_dir)
 
 ;;******************************** CONSTRUCT AUXILIARY DATA STRUCTURE ********************************
 

--- a/stix/idl/io/stx_read_pixel_data_fits_file.pro
+++ b/stix/idl/io/stx_read_pixel_data_fits_file.pro
@@ -252,7 +252,6 @@ pro stx_read_pixel_data_fits_file, fits_path, time_shift, alpha = alpha, primary
     pixel_masks:data.pixel_masks,$
     detector_masks:data.detector_masks,$
     energy_bin_mask: energy_bin_mask,$
-    num_pixel_sets:data.num_pixel_sets,$
-    num_energy_groups:data.num_energy_groups }
+    num_pixel_sets:data.num_pixel_sets}
 
 end


### PR DESCRIPTION
`num_engergy_groups` wasn't really useful as it doesn't correspond to the number of energy channels see i4Ds/STIXCore/issues/367