### PR TITLE
Implement compatibility with xspec

### DIFF
--- a/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
+++ b/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
@@ -70,7 +70,7 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   print, 'Event start time :  ',  header_start_time
   print, " "
 
-  ;For correct energy calibration in is necessary to determine the Energy Lookup Table (ELUT)
+  ; For correct energy calibration it is necessary to determine the Energy Lookup Table (ELUT)
   ; applied in flight when the observation was taken
   elut_filename = stx_date2elut_file(header_start_time)
   print, 'The ELUT applied at this time was : ', elut_filename
@@ -150,10 +150,10 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   spex_drmfile_cpd  = 'stx_srm_2202080013.fits'
 
 
-  ;At the low end we fit to the lowest science energy STIX observes of 4 keV
+  ;At the low end we fit to the lowest science energy STIX observed of 4 keV.
   ;For up to moderate events the science energy channels 28 - 32 keV and 32 - 36 keV are dominated by lines in the
-  ;calibration source are 31 and 35 keV. For this events it is reasonable to fit up to 28 keV
-  spex_erange= [4.0000000D, 28.000000D]
+  ;calibration source at 31 and 35 keV. For these events it is reasonable to fit up to 28 keV
+  spex_erange= [4.0D, 28.0D]
 
 
   ;The pre-flare background is taken as a five minute interval before the start of the flare
@@ -206,7 +206,7 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   ;Several necessary corrections are also applied to the data here
   ;This fit uses the option of directly passing in the location in the STIX coordinate frame.
   ;After this is called the spectrum and srm FITS files will be generated.
-  ;The routine will load these files into an OSPEX object which is it will also pass out so that further parameters
+  ;The routine will load these files into an OSPEX object, which it will also pass out so that further parameters
   ;can be applied and the fitting performed.
   stx_convert_spectrogram, $
     fits_path_data = fits_path_data_spec, $

--- a/stix/idl/processing/spectrogram/mk_rate_hdr.pro
+++ b/stix/idl/processing/spectrogram/mk_rate_hdr.pro
@@ -1,0 +1,162 @@
+;==============================================================================
+;+
+; Name: mk_rate_hdr
+;
+; Category: HESSI, UTIL
+;
+; Purpose: Make a basic FITS header for a RATE EXTENSION and merge it
+; with an optional input header.
+;
+; Calling sequence:
+; new_hdr = mk_rate_hdr( hdr, N_ROWS=256 )
+;
+; Inputs:
+; hdr - FITS header to merge with rate header.
+;
+; Outputs:
+; Returns a valid FITS RATE extension header.
+;
+; Input keywords:
+; N_ROWS - number of rows in RATE extension
+; EVENT_LIST - Set if the extension is an event list, not a rate.
+;
+; Output keywords:
+; ERR_MSG = error message.  Null if no error occurred.
+; ERR_CODE - 0/1 if [ no error / an error ] occurred during execution.
+;
+; Calls:
+; fxaddpar, fxbhmake, is_member, trim, merge_fits_hdrs
+;
+; Written: Paul Bilodeau, RITSS / NASA-GSFC, 18-May-2001
+;
+; Modification History:
+; 28-June-2001 Paul Bilodeau - added event_list keyword.  Removed N_CHAN
+;   keyword and ability to merge time independent data into the header.
+; 01-Sep-2004  Sandhia Bansal - Remove TIME-OBS and TIME-END.  This information
+;                               is already included in DATE-OBS and DATE-END.
+; 03-Sep-2004  Sandhia Bansal - Added several keywords that are required for
+;                 RATE extension. The values are now passed to this function via
+;                 rate_struct structure.  Also add the fitswrite object fptr to
+;                 the argument list so that the keys can be written via this pointer
+;                 instead of using fx-routines directly.
+; 24-Sep-2004  Sandhia Bansal - Write Author keyword.
+; 09-Nov-2004  Sandhia Bansal - Write GEOAREA keyword.
+; 20-Nov-2004  Sandhia Bansal - Write BACKAPP, DEADAPP, VIGNAPP, OBSERVER AND
+;                               TIMVERSN keywords.
+; 26-Apr-2019, Kim Tolbert - prevent a crash by making sure rate_hdr is defined even if hdr isn't
+; 16-Jul-2024, F. Schuller (AIP) - correct typos in header keywords
+; 
+;-
+;------------------------------------------------------------------------------
+FUNCTION mk_rate_hdr, hdr, rate_struct, N_ROWS=n_rows, EVENT_LIST=event_list, $
+  ERR_MSG=err_msg, ERR_CODE=err_code, fptr=fptr, _EXTRA=_extra
+
+  err_code = 1
+  err_msg = ''
+
+  CATCH, err
+  IF err NE 0 THEN BEGIN
+    err_msg = !err_string
+    RETURN, ''
+  ENDIF
+
+  IF N_Elements( n_rows ) EQ 0L THEN n_rows = -1L
+
+  IF n_rows LE 0L THEN BEGIN
+    err_msg = 'Cannot initialize header with ' + trim( n_rows ) + ' rows.'
+    RETURN, ''
+  ENDIF
+
+  extname = Keyword_Set( event_list ) ? 'EVENTS' : 'RATE'
+
+
+  ;fxbhmake, rate_hdr, n_rows, /DATE
+  fptr->Addpar, 'EXTNAME',  extname, 'Extension Name'
+  fptr->Addpar, 'TELESCOP', rate_struct.telescope, 'Name of the Telescope or Mission'
+  fptr->Addpar, 'INSTRUME', rate_struct.instrument, 'Name of the instrument'
+  fptr->Addpar, 'FILTER',   rate_struct.filter, 'Filter in use'
+  fptr->Addpar, 'OBJECT',   rate_struct.object, 'Observed object'
+  fptr->Addpar, 'RA',       rate_struct.ra, 'Right Ascension (in degrees) '
+  fptr->Addpar, 'DEC',      rate_struct.dec, 'Declination (in degrees)'
+  fptr->Addpar, 'RA_NOM',   rate_struct.ranom
+  fptr->Addpar, 'DEC_NOM',  rate_struct.decnom
+  fptr->Addpar, 'ORIGIN',   rate_struct.origin
+
+  fptr->Addpar, 'TIMEUNIT', rate_struct.timeunit, 'Unit for TIMEZERO, TSTARTI and TSTOPI'
+  fptr->Addpar, 'TIMEREF',  rate_struct.timeref, 'Reference frame for the times'
+  fptr->Addpar, 'MJDREF',   float(rate_struct.mjdref), 'TIMESYS in MJD (d)'
+  fptr->Addpar, 'TIMESYS',  rate_struct.timesys, 'Reference time in YYYY MM DD hh:mm:ss'
+  fptr->Addpar, 'TIMEZERO', rate_struct.timezero, 'Start day of the first bin rel to TIMESYS'
+  fptr->Addpar, 'TSTARTI',  rate_struct.tstarti, 'Integer portion of start time rel to TIMESYS'
+  fptr->Addpar, 'TSTARTF',  rate_struct.tstartf, 'Fractional portion of start time'
+  fptr->Addpar, 'TSTOPI',   rate_struct.tstopi, 'Integer portion of stop time rel to TIMESYS'
+  fptr->Addpar, 'TSTOPF',   rate_struct.tstopf, 'Fractional portion of stop time'
+  fptr->Addpar, 'TASSIGN',  rate_struct.tassign, 'Place of time assignment'
+  fptr->Addpar, 'TIERRELA', rate_struct.tierrela, 'Relative time error'
+  fptr->Addpar, 'TIERABSO', rate_struct.tierabso, 'Absolute time error'
+  fptr->Addpar, 'ONTIME',   rate_struct.exposure, 'Exposure time in seconds'
+  fptr->Addpar, 'TELAPSE',  rate_struct.telapse, 'Elapsed time in seconds'
+  fptr->Addpar, 'CLOCKCOR', rate_struct.clockcor, 'Clock Correction to UT'
+  fptr->Addpar, 'POISSERR', rate_struct.poisserr, 'Poission Error'
+  fptr->Addpar, 'VERSION',  rate_struct.version, 'File format version'
+
+  fptr->Addpar, 'EQUINOX',  rate_struct.equinox, 'Equinox of celestial coordinate system'
+  fptr->Addpar, 'RADECSYS', rate_struct.radecsys, 'Coordinate frame used for equinox'
+  fptr->Addpar, 'HDUCLASS', 'OGIP', 'File conforms to OGIP/GSFC convention'
+  fptr->Addpar, 'HDUCLAS1', 'SPECTRUM', 'File contains spectrum'
+  fptr->Addpar, 'HDUCLAS2', rate_struct.hduclas2, 'Extension contains a spectrum'
+  fptr->Addpar, 'HDUCLAS3', 'RATE', 'Extension contains rates'
+  fptr->Addpar, 'HDUCLAS4', 'TYPE:II', 'Multiple PHA files contained'
+  fptr->Addpar, 'HDUVERS',  '1.2', 'File conforms to this version of OGIP'
+  fptr->Addpar, 'TIMVERSN', 'OGIP/93-003', 'OGIP memo number where the convention used'
+  fptr->Addpar, 'ANCRFILE',  rate_struct.ancrfile, 'Name of the corresponding ancillary response file'
+  fptr->Addpar, 'AREASCAL',  rate_struct.areascal, 'Area scaling factor'
+  fptr->Addpar, 'BACKFILE',  rate_struct.backfile, 'Name of the corresponding background file'
+  fptr->Addpar, 'BACKSCAL',  rate_struct.backscal, 'Background scaling factor'
+  fptr->Addpar, 'CORRFILE',  rate_struct.corrfile, 'Name of the corresponding correction file'
+  fptr->Addpar, 'CORRSCAL',  rate_struct.corrscal, 'Correction scaling factor'
+  fptr->Addpar, 'EXPOSURE',  rate_struct.exposure, 'Integration time, corrected for deadtime and data drop-out etc.'
+  fptr->Addpar, 'GROUPING',  rate_struct.grouping, 'No grouping of data has been defined'
+  fptr->Addpar, 'QUALITY',   rate_struct.quality, 'No quality information is specified'
+  fptr->Addpar, 'DETCHANS',  rate_struct.detchans, 'Total number of detector channels available'
+  fptr->Addpar, 'CHANTYPE',  rate_struct.chantype, 'Channels assigned by detector electronics'
+  fptr->Addpar, 'GEOAREA',   rate_struct.area, 'Detector area for data in fit results (cm^2)'
+
+  fptr->Addpar, 'VIGNET',  rate_struct.vignet
+  fptr->Addpar, 'DETNAM',  rate_struct.detnam, 'Detector name'
+  fptr->Addpar, 'NPIXSOU', rate_struct.npixsou
+  fptr->Addpar, 'AUTHOR',  rate_struct.author, 'Name of program that produced this file'
+
+  fptr->Addpar, 'BACKAPP', rate_struct.backapp, 'Flag to indicate whether correction was applied'
+  fptr->Addpar, 'DEADAPP', rate_struct.deadapp, 'Flag to indicate whether correction was applied'
+  fptr->Addpar, 'VIGNAPP', rate_struct.vignapp, 'Flag to indicate whether correction was applied'
+
+  fptr->Addpar, 'OBSERVER', rate_struct.observer, 'Name of the user who genrated the file'
+
+  fptr->Addpar, 'TIMVERSN', rate_struct.timversn, 'OGIP memo number where the convention used'
+
+
+  IF Size( hdr, /TYPE ) EQ 7 THEN BEGIN
+    rate_hdr = merge_fits_hdrs( hdr, fptr->getheader(), ERR_MSG=err_msg, $
+      ERR_CODE=err_code )
+
+    ;rate_hdr = merge_fits_hdrs( hdr, rate_hdr, ERR_MSG=err_msg, $
+    ;  ERR_CODE=err_code )
+    IF err_code THEN RETURN, 0
+  ENDIF ELSE begin
+    rate_hdr = fptr->getheader()  ; added 26-Apr-2019
+    err_code = 0
+  ENDELSE
+
+  ; remove SIMPLE or EXTEND keywords - they don't belong in an extension header
+  non_simple = $
+    Where( Strmid( Strupcase(rate_hdr), 0, 6) NE 'SIMPLE', n_non_simple )
+  IF n_non_simple GT 0L THEN rate_hdr = rate_hdr[ non_simple ]
+
+  non_extend = $
+    Where( Strmid( Strupcase(rate_hdr), 0, 6) NE 'EXTEND', n_non_extend )
+  IF n_non_extend GT 0L THEN rate_hdr = rate_hdr[ non_extend ]
+
+  RETURN, rate_hdr
+
+END

--- a/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
@@ -8,9 +8,9 @@
 ;
 ; :description:
 ;    This procedure reads a STIX science data x-ray compaction level 1 (compressed pixel data file) and converts it to a spectrogram
-;    file which can be read in by OSPEX. This spectrogram is in the from of an array in energy and time so individual pixel and detector counts
+;    file which can be read in by OSPEX. This spectrogram is in the form of an array in energy and time so individual pixel and detector counts
 ;    are summed. A corresponding detector response matrix file is also produced. If a background file is supplied this will be subtracted
-;    A number of corrections for light travel time,
+;    A number of corrections for light travel time, (...) are applied.
 ;
 ; :categories:
 ;    spectroscopy

--- a/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_pixel_data.pro
@@ -74,6 +74,9 @@
 ;                     If set open OSPEX GUI and plot lightcurve in standard quicklook energy bands
 ;                     where there is data present
 ;
+;    xspec : in, type="boolean", default="0"
+;                     If set, generate SRM file compatible with XSPEC rather than OSPEX.
+;
 ;    ospex_obj : out, type="OSPEX object"
 ;
 ;
@@ -95,6 +98,7 @@
 ;    15-Mar-2023 - ECMD (Graz), updated to handle release version of L1 FITS files
 ;    16-Jun-2023 - ECMD (Graz), for a source location dependent response estimate, the location in HPC and the auxiliary ephemeris file must be provided.
 ;    06-Dec-2023 - ECMD (Graz), added silent keyword, more information is now printed if not set
+;    2024-07-12, F. Schuller (AIP): added optional keyword xspec
 ;
 ;-
 pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fits_path_bk, $
@@ -102,13 +106,14 @@ pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fit
   aux_fits_file = aux_fits_file, flare_location_hpc = flare_location_hpc, flare_location_stx = flare_location_stx, $
   det_ind = det_ind, pix_ind = pix_ind, elut_correction = elut_correction, shift_duration = shift_duration, $
   no_attenuation = no_attenuation, sys_uncert = sys_uncert, generate_fits = generate_fits, specfile = specfile, $
-  srmfile = srmfile, silent = silent, background_data = background_data, plot = plot, ospex_obj = ospex_obj
+  srmfile = srmfile, silent = silent, background_data = background_data, plot = plot, xspec=xspec, ospex_obj = ospex_obj
 
   default, shift_duration, 0
   default, plot, 1
   default, det_ind, 'top24'
   default, elut_correction, 1 
   default, silent, 0
+  default, xspec, 0
 
   if n_elements(time_shift) eq 0 then begin
   if ~keyword_set(silent) then begin
@@ -320,7 +325,7 @@ pro  stx_convert_pixel_data, fits_path_data = fits_path_data, fits_path_bk = fit
     data_level = data_level, data_dims = data_dims, fits_path_bk = fits_path_bk, fits_path_data = fits_path_data,$
     aux_fits_file = aux_fits_file, flare_location_hpc = flare_location_hpc, flare_location_stx = flare_location_stx, $
     eff_ewidth = eff_ewidth, sys_uncert = sys_uncert, plot = plot, background_data = background_data, silent = silent, $
-    elut_correction = elut_correction, fits_info_params = fits_info_params, ospex_obj = ospex_obj
+    elut_correction = elut_correction, fits_info_params = fits_info_params, xspec=xspec, ospex_obj = ospex_obj
 
 end
 

--- a/stix/idl/processing/spectrogram/stx_convert_science_data2ospex.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_science_data2ospex.pro
@@ -264,7 +264,9 @@ pro stx_convert_science_data2ospex, spectrogram = spectrogram, specpar = specpar
   fstart_time = time2fid(atime(stx_time2any((spectrogram.time_axis.time_start)[0])),/full,/time)
 
   default, specfilename, 'stx_spectrum_' + strtrim(uid,2) + '.fits'
-  default, srmfilename,  'stx_srm_'      + strtrim(uid,2) + '.fits'
+;  default, srmfilename,  'stx_srm_'      + strtrim(uid,2) + '.fits'
+  if ~keyword_set(srmfilename) then $
+    srmfilename = xspec ? 'stx_srm_' + strtrim(uid,2) + '_XSPEC.fits' : 'stx_srm_' + strtrim(uid,2) + '.fits'
 
 
   if keyword_set(pickfile) then begin

--- a/stix/idl/processing/spectrogram/stx_convert_science_data2ospex.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_science_data2ospex.pro
@@ -290,7 +290,8 @@ pro stx_convert_science_data2ospex, spectrogram = spectrogram, specpar = specpar
 
   ospex_obj = stx_fsw_sd_spectrogram2ospex( spectrogram, specpar = specpar, time_shift= time_shift, ph_energy_edges = ph_in, $
     /include_damage, generate_fits = generate_fits, xspec = xspec, /tail, livetime_fraction = eff_livetime_fraction, $
-    dist_factor = dist_factor, flare_location_stx = flare_location_stx, sys_uncert = sys_uncert, fits_info_params = fits_info_params, background_data = background_data, silent = silent)
+    dist_factor = dist_factor, flare_location_stx = flare_location_stx, sys_uncert = sys_uncert, fits_info_params = fits_info_params, $
+    background_data = background_data, silent = silent)
 
   if keyword_set(plot) then begin
     ospex_obj ->gui

--- a/stix/idl/processing/spectrogram/stx_convert_spectrogram.pro
+++ b/stix/idl/processing/spectrogram/stx_convert_spectrogram.pro
@@ -65,6 +65,9 @@
 ;                     If set open OSPEX GUI and plot lightcurve in standard quicklook energy bands
 ;                     where there is data present
 ;
+;    xspec : in, type="boolean", default="0"
+;                     If set, generate SRM file compatible with XSPEC rather than OSPEX.
+;    
 ;    ospex_obj : out, type="OSPEX object"
 ;
 ;
@@ -85,6 +88,7 @@
 ;    15-Mar-2023 - ECMD (Graz), updated to handle release version of L1 FITS files
 ;    16-Jun-2023 - ECMD (Graz), for a source location dependent response estimate, the location in HPC and the auxiliary ephemeris file must be provided.
 ;    06-Dec-2023 - ECMD (Graz), added silent keyword, more information is now printed if not set
+;    2024-07-12, F. Schuller (AIP): added optional keyword xspec
 ;
 ;-
 pro  stx_convert_spectrogram, fits_path_data = fits_path_data, fits_path_bk = fits_path_bk,$
@@ -93,11 +97,12 @@ pro  stx_convert_spectrogram, fits_path_data = fits_path_data, fits_path_bk = fi
   keep_short_bins = keep_short_bins, apply_time_shift = apply_time_shift, elut_correction = elut_correction, $
   shift_duration = shift_duration, no_attenuation = no_attenuation, sys_uncert = sys_uncert, $
   generate_fits = generate_fits, specfile = specfile, srmfile = srmfile, silent = silent, $
-  background_data = background_data, plot = plot, ospex_obj = ospex_obj
+  background_data = background_data, plot = plot, xspec=xspec, ospex_obj = ospex_obj
 
   default, plot, 1
   default, silent, 0
-
+  default, xspec, 0
+  
   if n_elements(time_shift) eq 0 then begin
     if ~keyword_set(silent) then begin
     message, 'Time shift value is not set. Using default value of 0 [s].', /info
@@ -260,7 +265,7 @@ endif
     data_dims = data_dims, fits_path_bk = fits_path_bk, fits_path_data = fits_path_data, $
     elut_correction = elut_correction, eff_ewidth = eff_ewidth, fits_info_params = fits_info_params, sys_uncert = sys_uncert, $
     aux_fits_file = aux_fits_file, flare_location_hpc = flare_location_hpc, flare_location_stx = flare_location_stx, $
-    silent = silent, background_data = background_data, plot = plot, generate_fits = generate_fits, ospex_obj = ospex_obj
+    silent = silent, background_data = background_data, plot = plot, generate_fits = generate_fits, xspec=xspec, ospex_obj = ospex_obj
 
 end
 

--- a/stix/idl/processing/spectrogram/stx_fsw_sd_spectrogram2ospex.pro
+++ b/stix/idl/processing/spectrogram/stx_fsw_sd_spectrogram2ospex.pro
@@ -166,6 +166,10 @@ function stx_fsw_sd_spectrogram2ospex, spectrogram, specpar = specpar, time_shif
       if cb7 gt 0 then sys_err[idx_below7kev] = 0.07
 
       sys_err = rebin(sys_err, n_energies,ntimes)
+      ; FSc, 2024-07-18: see below:
+      ; ospex_obj->set, spex_uncert = sys_uncert
+      ; therefore:
+      sys_uncert = sys_err
     endif
 
 

--- a/stix/idl/processing/spectrogram/stx_fsw_sd_spectrogram2ospex.pro
+++ b/stix/idl/processing/spectrogram/stx_fsw_sd_spectrogram2ospex.pro
@@ -166,10 +166,6 @@ function stx_fsw_sd_spectrogram2ospex, spectrogram, specpar = specpar, time_shif
       if cb7 gt 0 then sys_err[idx_below7kev] = 0.07
 
       sys_err = rebin(sys_err, n_energies,ntimes)
-      ; FSc, 2024-07-18: see below:
-      ; ospex_obj->set, spex_uncert = sys_uncert
-      ; therefore:
-      sys_uncert = sys_err
     endif
 
 

--- a/stix/idl/processing/spectrogram/stx_make_spectrum_header.pro
+++ b/stix/idl/processing/spectrogram/stx_make_spectrum_header.pro
@@ -96,16 +96,13 @@ pro stx_make_spectrum_header,specfile = specfile, $
 
   currtime = strmid(anytim(!stime, /ccsds), 0, 19)
   fxaddpar, header, 'DATE', currtime, 'File creation date (YYYY-MM-DDThh:mm:ss UTC)'
-  fxaddpar, header, 'ORIGIN', 'STIX', $
-    'Spectrometer Telescope for Imaging X-rays'
+  fxaddpar, header, 'ORIGIN', 'STIX', 'Spectrometer Telescope for Imaging X-rays'
   observer = getenv( 'USER' )
   if observer eq '' then observer = 'Unknown'
-  fxaddpar, header, 'OBSERVER', observer, $
-    'Usually the name of the user who generated file'
+  fxaddpar, header, 'OBSERVER', observer, 'Usually the name of the user who generated file'
   fxaddpar, header, 'TELESCOP', 'Solar Orbiter', 'Name of the Telescope or Mission'
   fxaddpar, header, 'INSTRUME', 'STIX', 'Name of the instrument'
   fxaddpar, header, 'OBJECT', 'Sun', 'Object being observed'
-
 
   fxaddpar, header, 'TIME_UNIT', 1
   fxaddpar, header, 'ENERGY_L', min( energy_band )

--- a/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
+++ b/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
@@ -158,6 +158,8 @@ data_rate = mrdfits(filename, 1, head_rate)
 sxaddpar, head_rate, 'HDUCLAS3', 'RATE', '  Extension contains rates', after='HDUCLAS2'
 sxaddpar, head_rate, 'HDUCLAS4', 'TYPE:II', '  Multiple PHA files contained', after='HDUCLAS3'
 sxdelpar, head_rate, 'HDUCALS3'
+; POISSERR should be a boolean (not an integer)
+sxaddpar, head_rate, 'POISSERR', boolean(0), '  Poisson Error'
 fxwrite, filename, prim_header, ERRMSG=err_msg
 mwrfits, data_rate, filename, head_rate
 

--- a/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
+++ b/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
@@ -1,0 +1,171 @@
+;==============================================================================
+;+
+; Name: stx_spectrum2fits
+;
+; Category: FITS, UTIL
+;
+; Purpose: Write spectral rate data to a FITS file.
+;
+; Calling sequence:
+;     spectrum2fits, filename, WRITE_PRIMARY_HEADER=1,
+;       PRIMARY_HEADER=primary_header, EXTENSION_HEADER=extension_header,
+;       DATA=rate_data, ERROR=rate_error, TSTART=start_times, TSTOP=stop_times,
+;       MINCHAN=1, MAXCHAN=number_of_channels,
+;       E_MIN=min_channel_energies, E_MAX=max_channel_energies, E_UNIT='keV',
+;       ERR_CODE=had_err, ERR_MSG=err_msg
+;
+; Inputs:
+; filename - name of FITS file to write.
+;
+; Outputs:
+;
+; Input keywords:
+; WRITE_PRIMARY_HEADER - set this keyword to write a primary header to
+;                        the file.
+; PRIMARY_HEADER - primary header for the file.  This contains any information
+;       that should be in the primary header in addition to
+;       the mandatory keywords.  Only used if
+;       WRITE_PRIMARY_HEADER is set.
+; EXTENSION_HEADER - header for the RATE extension, with any necessary
+;         keywords.
+; EVENT_LIST - set this keyword if a list of events is being written
+;              to the file.
+; _EXTRA - Any keywords set in _EXTRA will be integrated into the extension
+;      structure array based on the number of elements.  If an entry has
+;      n_channel entries, it will be duplicated n_input spectra
+;      times and will be stored as a vector in the structure
+;      array.  If it has n_input spectra entries, each entry will
+;      be a scalar in the corresponding structure array element.
+;      The spectral data are passed in via the DATA keyword.
+;
+; The following keywords control writing data into the RATE
+; extension and are processed in wrt_rate_ext:
+; DATA - a [n_channel x n_input spectra / n_channel x n_detector x $
+;    n_input_spectra] array containing the the
+;    counts/s or counts for each spectrum in each channel.
+; ERROR - an array containing the uncertainties on DATA.  Deafults to the
+;     square root of DATA.
+; COUNTS - set if the column name for the data entry should be COUNTS
+;          instead of the default RATE.
+; UNITS - units for DATA
+;  - a [ n_channel x n_input spectra / n_input spectra ] array
+;            containing the livetime for each [ spectrum channel / spectrum ]
+; TIMECEN - Full time or time from TIMEZERO for each input spectrum or
+;           event.  Stored as TIME column within RATE extension.
+; SPECNUM - Index to each spectrum.
+; TIMEDEL - The integration time for each channel of each spectrum or
+;           each spectrum.
+; DEADC - Dead Time Correction for each channel of each spectra, each
+;     spectrum, or each channel.  One of DEADC / LIVETIME should
+;     be set.  If n_chan elements, this will be set in the header
+;     for this extension.
+; BACKV - background counts for each channel of each spectrum - OPTIONAL.
+; BACKE - error on background counts for each channel of each spectrum.
+;         OPTIONAL.  Defaults to the square root of the BACKV if BACKV is set.
+;
+; The following keywords control the data that are written in the ENEBAND
+; extension are passed to wrt_eneband_ext:
+; NUMBAND - number of energy bands.
+; MINCHAN - a numband element array containing the minimum channel number in
+;       each band.
+; MAXCHAN - a numband element array containing the maximum channel number in
+;       each band.
+; E_MIN - a numband element array containing the minimum energy in each band.
+; E_MAX - a numband element array containing the maximum energy in each band.
+;
+; Output keywords:
+; ERR_MSG = error message.  Null if no error occurred.
+; ERR_CODE - 0/1 if [ no error / an error ] occurred during execution.
+;
+; Calls:
+; arr2str, str2arr, str2chars
+;
+;
+; Modification History:
+;   2002: Written by Paul Bilodeau, RITSS / NASA-GSFC
+;   2024-07-16, F. Schuller (AIP): 
+;    - copy from ssw/gen/idl/fits/spectrum2fits.pro 
+;    - adapted to STIX data and compatibility with XSPEC:
+;      * added columns EXPOSURE and SYS_ERR
+;      * 
+;   
+;-
+;------------------------------------------------------------------------------
+PRO stx_spectrum2fits, filename, $
+                   WRITE_PRIMARY_HEADER=write_primary_header, $
+                   PRIMARY_HEADER=prim_header, $
+                   EXTENSION_HEADER=ext_header, $
+                   NUMBAND=numband, $
+                   MINCHAN=minchan, $
+                   MAXCHAN=maxchan, $
+                   E_MIN=e_min, $
+                   E_MAX=e_max, $
+                   E_UNIT=e_unit, $
+                   EVENT_LIST=event_list, $
+                   _EXTRA=_extra, $
+                   ERR_MSG=err_msg, $
+                   ERR_CODE=err_code
+
+err_msg = ''
+err_code = 0
+
+IF Size( filename, /TYPE ) NE 7 THEN BEGIN
+    err_msg = 'Need filename as first input.'
+    GOTO, ERROR_EXIT
+ENDIF
+
+IF Keyword_Set( write_primary_header ) THEN BEGIN
+    ; Create the primary header if necessary.
+    IF Size( prim_header, /TYPE ) NE 7 THEN $
+      fxhmake, prim_header, /EXTEND, /DATE
+
+    fxaddpar, prim_header, 'AUTHOR', 'SPECTRUM2FITS'
+    fxaddpar, prim_header, 'RA', 0.0, 'Source right ascension in degrees'
+    fxaddpar, prim_header, 'DEC', 0.0, 'Source declination in degrees'
+    fxaddpar, prim_header, 'RA_NOM', 0.0, 'r.a. nominal pointing in degrees'
+    fxaddpar, prim_header, 'DEC_NOM', 0.0, 'dec. nominal pointing in degrees'
+    fxaddpar, prim_header, 'EQUINOX', 2000.0, 'Equinox of celestial coordinate system'
+    fxaddpar, prim_header, 'RADECSYS', 'FK5', 'Coordinate frame used for equinox'
+    fxaddpar, prim_header, 'TIMVERSN', 'OGIP/93-003', 'OGIP memo number where the convention used'
+    fxaddpar, prim_header, 'VERSION', '1.0', 'File format version number'
+
+    fxwrite, filename, prim_header, ERRMSG=err_msg
+
+    IF err_msg NE '' THEN BEGIN
+        MESSAGE, 'ERROR writing primary header to ' + filename, /CONTINUE
+        RETURN
+    ENDIF
+ENDIF
+
+ext_kw_list = [  'SPEC_NUM', 'CHANNEL', 'TIMECEN', 'TIMEDEL', 'LIVETIME', 'DEADC', $
+      'BACKV', 'BACKE', 'TIMEZERO', 'TSTART', 'TSTOP', 'EXPOSURE', 'SYS_ERR' ]
+
+ext_st_list = [ 'SPEC_NUM', 'CHANNEL', 'TIME', 'TIMEDEL', 'LIVETIME', 'DEADC', $
+      'BACKV', 'BACKE', 'TIMEZERO', 'TSTART', 'TSTOP', 'EXPOSURE', 'SYS_ERR' ]
+
+wrt_rate_ext, filename, HEADER=ext_header, _EXTRA=_extra, $
+              KW_LIST=ext_kw_list, ST_LIST=ext_st_list, $
+              EVENT_LIST=event_list, ERR_MSG=err_msg, ERR_CODE=err_code
+
+IF err_code THEN BEGIN
+    MESSAGE, 'ERROR writing RATE extension to ' + filename, /CONTINUE
+    RETURN
+ENDIF
+
+wrt_eneband_ext, filename, HEADER=ext_header, NUMBAND=numband, $
+                 MINCHAN=minchan, MAXCHAN=maxchan, E_MIN=e_min, E_MAX=e_max, $
+                 E_UNIT=e_unit, ERR_MSG=err_msg, ERR_CODE=err_code
+
+IF err_code THEN BEGIN
+    MESSAGE, 'ERROR writing ENEBAND extension to ' + filename, /CONTINUE
+    RETURN
+ENDIF
+
+ERROR_EXIT:
+err_code = err_msg NE ''
+IF err_code THEN BEGIN
+    MESSAGE, err_msg, /CONTINUE
+    err_msg = 'SPECTRUM2FITS: ' + err_msg
+ENDIF
+
+END

--- a/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
+++ b/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
@@ -88,6 +88,7 @@
 ;    - adapted to STIX data and compatibility with XSPEC:
 ;      * added columns EXPOSURE and SYS_ERR
 ;      * correct header keywords HDUCLAS3 and HDUCLAS4 in extension RATE
+;      * update HDUCLAS2 keyword depending whether background was subtracted or not
 ;   
 ;-
 ;------------------------------------------------------------------------------
@@ -160,6 +161,13 @@ sxaddpar, head_rate, 'HDUCLAS4', 'TYPE:II', '  Multiple PHA files contained', af
 sxdelpar, head_rate, 'HDUCALS3'
 ; POISSERR should be a boolean (not an integer)
 sxaddpar, head_rate, 'POISSERR', boolean(0), '  Poisson Error'
+; if background subtracted, update keyword
+bg_sub = sxpar(head_rate, 'BACKAPP')
+if bg_sub eq 1 then begin
+  sxaddpar, head_rate, 'HDUCLAS2', 'NET', '  Extension contains a spectrum'
+  sxaddpar, head_rate, 'BACKFILE', 'none'
+endif else sxaddpar, head_rate, 'HDUCLAS2', 'TOTAL', '  Extension contains a spectrum'
+
 fxwrite, filename, prim_header, ERRMSG=err_msg
 mwrfits, data_rate, filename, head_rate
 

--- a/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
+++ b/stix/idl/processing/spectrogram/stx_spectrum2fits.pro
@@ -87,7 +87,7 @@
 ;    - copy from ssw/gen/idl/fits/spectrum2fits.pro 
 ;    - adapted to STIX data and compatibility with XSPEC:
 ;      * added columns EXPOSURE and SYS_ERR
-;      * 
+;      * correct header keywords HDUCLAS3 and HDUCLAS4 in extension RATE
 ;   
 ;-
 ;------------------------------------------------------------------------------
@@ -152,6 +152,16 @@ IF err_code THEN BEGIN
     RETURN
 ENDIF
 
+; Correct header keywords HDUCLAS3 and HDUCLAS4 (deeply hardcoded in mk_rate_hdr.pro)
+; FSchuller, 2024-07-17
+data_rate = mrdfits(filename, 1, head_rate)
+sxaddpar, head_rate, 'HDUCLAS3', 'RATE', '  Extension contains rates', after='HDUCLAS2'
+sxaddpar, head_rate, 'HDUCLAS4', 'TYPE:II', '  Multiple PHA files contained', after='HDUCLAS3'
+sxdelpar, head_rate, 'HDUCALS3'
+fxwrite, filename, prim_header, ERRMSG=err_msg
+mwrfits, data_rate, filename, head_rate
+
+; 2nd extension: ENEBAND
 wrt_eneband_ext, filename, HEADER=ext_header, NUMBAND=numband, $
                  MINCHAN=minchan, MAXCHAN=maxchan, E_MIN=e_min, E_MAX=e_max, $
                  E_UNIT=e_unit, ERR_MSG=err_msg, ERR_CODE=err_code

--- a/stix/idl/processing/spectrogram/stx_write_ospex_fits.pro
+++ b/stix/idl/processing/spectrogram/stx_write_ospex_fits.pro
@@ -147,7 +147,7 @@ pro stx_write_ospex_fits, $
     compatibility = compatibility,$
     any_specfile = any_specfile
 
-  units_arr = [ 'counts/s', 'counts/s', ' ', ' ', ' ', 's', 's' ]
+  units_arr = [ 'counts/s', 'counts/s', ' ', ' ', ' ', 's', 's', 's', ' ']
 
   backapp = fits_info_params.background_subtracted ? 'T' : 'F'
   backfile = fits_info_params.fits_background_file


### PR DESCRIPTION
This version gives the possibility to generate spectroscopic data files (and DRM) to be further processed either in OSPEX or in XSPEC. For that purpose, an optional boolean argument `xspec` was added to the procedures that convert L1 science data to ospex (or xspec) input data files.
In addition, it was necessary to create a local version of procedures `spectrum2fits` (renamed `stx_spectrum2fits`) and `mk_rate_hdr` in order to add some columns to the files that are generated, as required by xspec.
