### PR TITLE
Correct comment for keyword 'sumcase' in procedure header (fix #214)

### DIFF
--- a/stix/idl/processing/pixel_data/stx_construct_pixel_data_summed.pro
+++ b/stix/idl/processing/pixel_data/stx_construct_pixel_data_summed.pro
@@ -41,7 +41,7 @@
 ;             'stx_plot_selected_time_range' and for computing the total number of counts in the image. Default, indices of
 ;             the detectors from 10 to 3
 ;   
-;   sumcase: string indicating which pixels are summed. See the header of 'stx_calibrate_pixel_data' for 
+;   sumcase: string indicating which pixels are summed. See the header of 'stx_sum_pixel_data' for 
 ;            more information
 ;   
 ;   silent: if set, no message is printed and no plot is displayed

--- a/stix/idl/processing/pixel_data/stx_sum_pixel_data.pro
+++ b/stix/idl/processing/pixel_data/stx_sum_pixel_data.pro
@@ -22,7 +22,7 @@
 ;   sumcase: string indicating which pixels are summed. Options: 
 ;            - 'ALL': top row + bottom row + small pixels
 ;            - 'TOP': top row pixels only
-;            - 'BOTTOM': bottom row pixels only
+;            - 'BOT': bottom row pixels only
 ;            - 'TOP+BOT': top row + bottom row pixels
 ;            - 'SMALL': small pixels only
 ;            Default, 'TOP+BOT'


### PR DESCRIPTION
Made comment for keyword 'sumcase' in procedure header consistent with actual implementation