### PR TITLE
update for upper and lower bound

### DIFF
--- a/stix/idl/processing/imaging/stx_vis_fwdfit_pso.pro
+++ b/stix/idl/processing/imaging/stx_vis_fwdfit_pso.pro
@@ -78,7 +78,7 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
 
   n_sources = n_elements(configuration)
 
-  dummy0 = stx_hpc2stx_coord(vis[0].xyoffset, aux_data, /inverse)  ;Helioprojective Cartesian coordinate
+  flare_loc_HPC = stx_hpc2stx_coord(vis[0].xyoffset, aux_data, /inverse)  ;Helioprojective Cartesian coordinate
 
   if keyword_set(SRCIN) then begin
 
@@ -246,7 +246,7 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
 
   endif else begin
 
-    srcin = vis_fwdfit_pso_multiple_src_create(vis, configuration, aux_data = aux_data)
+    srcin = vis_fwdfit_pso_multiple_src_create(vis, configuration, flare_loc_HPC)
 
   endelse
 
@@ -254,10 +254,10 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
 
     for j=0, n_circle-1 do begin
       ;the solution for the position is sought in a rectangle centered in [0.,0.]
-      srcin.circle[j].lower_bound.l_b_x = srcin.circle[j].lower_bound.l_b_x - dummy0[0]
-      srcin.circle[j].upper_bound.u_b_x = srcin.circle[j].upper_bound.u_b_x - dummy0[0]
-      srcin.circle[j].lower_bound.l_b_y = srcin.circle[j].lower_bound.l_b_y - dummy0[1]
-      srcin.circle[j].upper_bound.u_b_y = srcin.circle[j].upper_bound.u_b_y - dummy0[1]
+      srcin.circle[j].lower_bound.l_b_x = srcin.circle[j].lower_bound.l_b_x - flare_loc_HPC[0]
+      srcin.circle[j].upper_bound.u_b_x = srcin.circle[j].upper_bound.u_b_x - flare_loc_HPC[0]
+      srcin.circle[j].lower_bound.l_b_y = srcin.circle[j].lower_bound.l_b_y - flare_loc_HPC[1]
+      srcin.circle[j].upper_bound.u_b_y = srcin.circle[j].upper_bound.u_b_y - flare_loc_HPC[1]
 
       ; upper and lower bound transformation: from the Solar Orbiter coordinate frame to the STIX coordinate frame
       this_l_b_x = srcin.circle[j].lower_bound.l_b_y
@@ -275,10 +275,10 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
   if n_ellipse gt 0 then begin
     for j=0, n_ellipse-1 do begin
       ;the solution for the position is sought in a rectangle centered in [0.,0.]
-      srcin.ellipse[j].lower_bound.l_b_x = srcin.ellipse[j].lower_bound.l_b_x - dummy0[0]
-      srcin.ellipse[j].upper_bound.u_b_x = srcin.ellipse[j].upper_bound.u_b_x - dummy0[0]
-      srcin.ellipse[j].lower_bound.l_b_y = srcin.ellipse[j].lower_bound.l_b_y - dummy0[1]
-      srcin.ellipse[j].upper_bound.u_b_y = srcin.ellipse[j].upper_bound.u_b_y - dummy0[1]
+      srcin.ellipse[j].lower_bound.l_b_x = srcin.ellipse[j].lower_bound.l_b_x - flare_loc_HPC[0]
+      srcin.ellipse[j].upper_bound.u_b_x = srcin.ellipse[j].upper_bound.u_b_x - flare_loc_HPC[0]
+      srcin.ellipse[j].lower_bound.l_b_y = srcin.ellipse[j].lower_bound.l_b_y - flare_loc_HPC[1]
+      srcin.ellipse[j].upper_bound.u_b_y = srcin.ellipse[j].upper_bound.u_b_y - flare_loc_HPC[1]
 
       ; upper and lower bound transformation: from the Solar Orbiter coordinate frame to the STIX coordinate frame
       this_l_b_x = srcin.ellipse[j].lower_bound.l_b_y
@@ -297,10 +297,10 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
   if n_loop gt 0 then begin
     for j=0, n_loop-1 do begin
       ;the solution for the position is sought in a rectangle centered in [0.,0.]
-      srcin.loop[j].lower_bound.l_b_x = srcin.loop[j].lower_bound.l_b_x - dummy0[0]
-      srcin.loop[j].upper_bound.u_b_x = srcin.loop[j].upper_bound.u_b_x - dummy0[0]
-      srcin.loop[j].lower_bound.l_b_y = srcin.loop[j].lower_bound.l_b_y - dummy0[1]
-      srcin.loop[j].upper_bound.u_b_y = srcin.loop[j].upper_bound.u_b_y - dummy0[1]
+      srcin.loop[j].lower_bound.l_b_x = srcin.loop[j].lower_bound.l_b_x - flare_loc_HPC[0]
+      srcin.loop[j].upper_bound.u_b_x = srcin.loop[j].upper_bound.u_b_x - flare_loc_HPC[0]
+      srcin.loop[j].lower_bound.l_b_y = srcin.loop[j].lower_bound.l_b_y - flare_loc_HPC[1]
+      srcin.loop[j].upper_bound.u_b_y = srcin.loop[j].upper_bound.u_b_y - flare_loc_HPC[1]
 
       ; upper and lower bound transformation: from the Solar Orbiter coordinate frame to the STIX coordinate frame
       this_l_b_x = srcin.loop[j].lower_bound.l_b_y
@@ -315,7 +315,7 @@ function stx_vis_fwdfit_pso, configuration, vis, aux_data, $
     endfor
   endif
 
-  param_out = vis_fwdfit_pso(configuration, this_vis, srcin, aux_data.ROLL_ANGLE * !dtor, $
+  param_out = vis_fwdfit_pso(configuration, this_vis, srcin, aux_data.ROLL_ANGLE * !dtor, flare_loc_HPC, $
                               n_birds = n_birds, tolerance = tolerance, maxiter = maxiter, $
                               uncertainty = uncertainty, $
                               imsize=imsize, pixel=pixel, $

--- a/stix/idl/processing/imaging/vis_fwdfit_func_pso.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_func_pso.pro
@@ -72,7 +72,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, 4*i+1] = xx[*, 4*i+1] * 0. + cos(roll_angle)*(double(param_opt[4*i+1])-mapcenter[0]) - sin(roll_angle)*(double(param_opt[4*i+2])-mapcenter[1])
-      ; double(param_opt[4*i+1]) - mapcenter[0]
       x_loc = reform(xx[*, 4*i+1], [n_particles,1])
 
       flag=1
@@ -88,7 +87,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, 4*i+2] = xx[*, 4*i+2] * 0. + sin(roll_angle)*(double(param_opt[4*i+1])-mapcenter[0]) + cos(roll_angle)*(double(param_opt[4*i+2])-mapcenter[1])
-      ; double(param_opt[4*i+2]) - mapcenter[1]
       y_loc = reform(xx[*,4*i+2], [n_particles,1])
 
       flag=1
@@ -213,7 +211,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, n_circle*4+6*i+1] = xx[*, n_circle*4+6*i+1] * 0. + cos(roll_angle)*(double(param_opt[n_circle*4+6*i+1])-mapcenter[0]) - sin(roll_angle)*(double(param_opt[n_circle*4+6*i+2])-mapcenter[1])
-      ;double(param_opt[n_circle*4+6*i+1]) - mapcenter[0]
       x_loc = reform(xx[*,n_circle*4+6*i+1], [n_particles,1])
 
       flag=1
@@ -229,7 +226,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, n_circle*4+6*i+2] = xx[*, n_circle*4+6*i+2] * 0. + sin(roll_angle)*(double(param_opt[n_circle*4+6*i+1])-mapcenter[0]) + cos(roll_angle)*(double(param_opt[n_circle*4+6*i+2])-mapcenter[1])
-      ;double(param_opt[n_circle*4+6*i+2]) - mapcenter[1]
       y_loc = reform(xx[*,n_circle*4+6*i+2], [n_particles,1])
 
       ; Take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.     
@@ -257,9 +253,7 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; Cause type conversion error.
       if flag then xx[*, n_circle*4+n_ellipse*6+7*i] = xx[*, n_circle*4+n_ellipse*6+7*i] * 0. + double(param_opt[n_circle*4+n_ellipse*6+7*i])
       flux = xx[*, n_circle*4+n_ellipse*6+7*i]
-      ;flux = reform(flux, [n_particles,1])
-      ;flux = flux # ones
-    
+
       eccos = reform(xx[*,n_circle*4+n_ellipse*6+7*i+4], [n_particles,1])
       ecsin = reform(xx[*,n_circle*4+n_ellipse*6+7*i+5], [n_particles,1])
     
@@ -337,7 +331,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, n_circle*4+n_ellipse*6+7*i+1] = xx[*, n_circle*4+n_ellipse*6+7*i+1] * 0. + cos(roll_angle)*(double(param_opt[n_circle*4+n_ellipse*6+7*i+1])-mapcenter[0]) - sin(roll_angle)*(double(param_opt[n_circle*4+n_ellipse*6+7*i+2])-mapcenter[1])
-      ;double(param_opt[n_circle*4+n_ellipse*6+7*i+1]) - mapcenter[0]
       x_loc = reform(xx[*,n_circle*4+n_ellipse*6+7*i+1], [n_particles,1])
     
       flag=1
@@ -353,7 +346,6 @@ function vis_fwdfit_func_pso, xx, extra = extra
       ; If the x and y coordinate are fixed, take into account the telescope rotation and transform the coordinates into the telescope coordinate frame.
       ; The co-ordinates must be in a rectangle centered in [0.,0.], so the mapcenter must be subtracted
       if flag then xx[*, n_circle*4+n_ellipse*6+7*i+2] = xx[*, n_circle*4+n_ellipse*6+7*i+2] * 0. + sin(roll_angle)*(double(param_opt[n_circle*4+n_ellipse*6+7*i+1])-mapcenter[0]) + cos(roll_angle)* (double(param_opt[n_circle*4+n_ellipse*6+7*i+2])-mapcenter[1])
-      ;+ double(param_opt[n_circle*4+n_ellipse*6+7*i+2]) - mapcenter[1]
       y_loc = reform(xx[*,n_circle*4+n_ellipse*6+7*i+2], [n_particles,1])
     
       flag=1

--- a/stix/idl/processing/imaging/vis_fwdfit_pso.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso.pro
@@ -44,8 +44,13 @@
 ;               PARAM_OPT  : struct containing the values of the parameters to keep fixed during the optimization.
 ;                           If an entry of 'param_opt' is set equal to 'fit', then the corresponding variable is optimized.
 ;                           Otherwise, its value is kept fixed equal to the entry of 'param_opt'
+;           
+;           IF THE X AND Y COORDINATE ARE FIXED, THEY MUST BE IN THE HELIOPROJECTIVE CARTESIAN COORDINATE.
+;           
 ;               LOWER_BOUND: struct containing the lower bound values of the variables to optimize.
 ;               UPPER_BOUND: struct containing the upper bound values of the variables to optimize.
+;               .
+;           THE UPPER AND LOWER BOUND FOR THE X AND Y COORDINATES MUST BE A RECTANGLE CENTRED AROUND ZERO.
 ;
 ;               For different shapes we have:
 ;                 - 'circle'  : param_opt, lower_bound, upper_bound = [flux, x location, y location, FWHM]
@@ -55,7 +60,9 @@
 ;                 - 'loop'    : param_opt = [flux, x location, y location, FWHM max, FWHM min, alpha, loop_angle]
 ;                               lower_bound, upper_bound = [flux, x location, y location, FWHM, ecc * cos(alpha), ecc * sin(alpha), loop_angle]
 ; 
-; roll_angle: Roll angle (radiant)
+;   roll_angle: Roll angle (radiant)
+;   flare_loc_HPC: flare position in Helioprojective Cartesian coordinate
+;
 ;
 ; KEYWORDS:
 ;   N_BIRDS     : number of particles used in PSO
@@ -92,7 +99,7 @@
 ;   volpara [at] dima.unige.it
 
 
-function vis_fwdfit_pso, configuration, vis, srcin, roll_angle, $
+function vis_fwdfit_pso, configuration, vis, srcin, roll_angle, flare_loc_HPC, $
                           n_birds = n_birds, tolerance = tolerance, maxiter = maxiter, $
                           uncertainty = uncertainty, $
                           imsize=imsize, pixel=pixel, $

--- a/stix/idl/processing/imaging/vis_fwdfit_pso.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso.pro
@@ -54,7 +54,8 @@
 ;                                 'ecc' is the eccentricity of the ellipse and 'alpha' is the orientation angle
 ;                 - 'loop'    : param_opt = [flux, x location, y location, FWHM max, FWHM min, alpha, loop_angle]
 ;                               lower_bound, upper_bound = [flux, x location, y location, FWHM, ecc * cos(alpha), ecc * sin(alpha), loop_angle]
-;
+; 
+; roll_angle: Roll angle (radiant)
 ;
 ; KEYWORDS:
 ;   N_BIRDS     : number of particles used in PSO
@@ -91,7 +92,7 @@
 ;   volpara [at] dima.unige.it
 
 
-function vis_fwdfit_pso, configuration, vis, srcin, $
+function vis_fwdfit_pso, configuration, vis, srcin, roll_angle, $
                           n_birds = n_birds, tolerance = tolerance, maxiter = maxiter, $
                           uncertainty = uncertainty, $
                           imsize=imsize, pixel=pixel, $
@@ -214,7 +215,8 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
                                ;and the number of parameters of the source shape)
     param_opt: param_opt, $
     mapcenter : vis.xyoffset, $
-    configuration: configuration }
+    configuration: configuration, $
+    roll_angle: roll_angle}
 
   if n_elements(configuration) eq 1 then begin
     if configuration[0] eq 'loop' then begin
@@ -254,8 +256,9 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
     for i=0, n_circle-1 do begin
       srcstr[i].srctype = 'circle'
       srcstr[i].srcflux = xopt[4*i]
-      srcstr[i].srcx    = xopt[4*i+1] + vis[0].xyoffset[0]
-      srcstr[i].srcy    = xopt[4*i+2] + vis[0].xyoffset[1]
+      ;The coordinates of the position are searched in a rectangle centered in [0.,0.], so the mapcenter must be added
+      srcstr[i].srcx = cos(roll_angle) * xopt[4*i+1] + sin(roll_angle) * xopt[4*i+2]+ vis[0].xyoffset[0]
+      srcstr[i].srcy = -sin(roll_angle) * xopt[4*i+1] + cos(roll_angle) * xopt[4*i+2]+ vis[0].xyoffset[1]
       srcstr[i].srcfwhm_max = xopt[4*i+3]
       srcstr[i].srcfwhm_min = xopt[4*i+3]
     endfor
@@ -271,8 +274,9 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
 
       srcstr[n_circle+i].eccen   = eccen
       srcstr[n_circle+i].srcflux = xopt[n_circle*4+6*i]
-      srcstr[n_circle+i].srcx    = xopt[n_circle*4+6*i+1] + vis[0].xyoffset[0]
-      srcstr[n_circle+i].srcy    = xopt[n_circle*4+6*i+2] + vis[0].xyoffset[1]
+      ;The coordinates of the position are searched in a rectangle centered in [0.,0.], so the mapcenter must be added
+      srcstr[n_circle+i].srcx = cos(roll_angle) * xopt[n_circle*4+6*i+1] + sin(roll_angle) * xopt[n_circle*4+6*i+2]+ vis[0].xyoffset[0]
+      srcstr[n_circle+i].srcy = -sin(roll_angle) * xopt[n_circle*4+6*i+1] + cos(roll_angle) * xopt[n_circle*4+6*i+2]+ vis[0].xyoffset[1]
       srcstr[n_circle+i].srcfwhm_max = xopt[n_circle*4+6*i+3] / (1-eccen^2)^0.25
       srcstr[n_circle+i].srcfwhm_min = xopt[n_circle*4+6*i+3] * (1-eccen^2)^0.25
       srcstr[n_circle+i].eccen   = eccen
@@ -287,13 +291,14 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
     for i=0, n_loop-1 do begin
       srcstr[n_circle+n_ellipse+i].srctype = 'loop'
 
-      ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*i*4+4]^2 + xopt[n_circle*4+6*n_ellipse+7*i*4+5]^2))
+      ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*i+4]^2 + xopt[n_circle*4+6*n_ellipse+7*i+5]^2))
       eccen = SQRT(1 - EXP(-2*ecmsr))
 
       srcstr[n_circle+n_ellipse+i].eccen   = eccen
       srcstr[n_circle+n_ellipse+i].srcflux = xopt[n_circle*4+6*n_ellipse+7*i]
-      srcstr[n_circle+n_ellipse+i].srcx    = xopt[n_circle*4+6*n_ellipse+7*i+1] + vis[0].xyoffset[0]
-      srcstr[n_circle+n_ellipse+i].srcy    = xopt[n_circle*4+6*n_ellipse+7*i+2] + vis[0].xyoffset[1]
+      ;The coordinates of the position are searched in a rectangle centered in [0.,0.], so the mapcenter must be added
+      srcstr[n_circle+n_ellipse+i].srcx = cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+1] + sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+2]+ vis[0].xyoffset[0]
+      srcstr[n_circle+n_ellipse+i].srcy = -sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+1] + cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+2]+ vis[0].xyoffset[1]
       srcstr[n_circle+n_ellipse+i].srcfwhm_max = xopt[n_circle*4+6*n_ellipse+7*i+3] / (1-eccen^2)^0.25
       srcstr[n_circle+n_ellipse+i].srcfwhm_min = xopt[n_circle*4+6*n_ellipse+7*i+3] * (1-eccen^2)^0.25
       srcstr[n_circle+n_ellipse+i].eccen   = eccen
@@ -401,7 +406,8 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
                                    ;and the number of parameters of the source shape)
         param_opt: param_opt, $
         mapcenter : vis.xyoffset, $
-        configuration: configuration }
+        configuration: configuration, $
+        roll_angle: roll_angle}
 
       xx_opt = []
       f = fltarr(Nruns)
@@ -421,7 +427,7 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         matrix_dist_circle  = fltarr(n_circle, n_circle)
         for i=0,n_circle-1 do begin
           for j=0,n_circle-1 do begin
-            d_i_j = sqrt((xopt[4*i+1] + vis[0].xyoffset[0] - srcstr[j].srcx )^2. + (xopt[4*i+2] + vis[0].xyoffset[1] - srcstr[j].srcy )^2.)
+            d_i_j = sqrt((cos(roll_angle) * xopt[4*i+1] + sin(roll_angle) * xopt[4*i+2] + vis[0].xyoffset[0] - srcstr[j].srcx )^2. + (-sin(roll_angle) * xopt[4*i+1] + cos(roll_angle) * xopt[4*i+2] + vis[0].xyoffset[1] - srcstr[j].srcy )^2.)
             matrix_dist_circle[j,i] = d_i_j
           endfor
         endfor
@@ -430,8 +436,10 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         coord_min = array_indices(matrix_dist_circle eq min(matrix_dist_circle), loc_dist_min0[0])
 
         trial_results[4*coord_min[0], n]   = xopt[4*coord_min[-1]]
-        trial_results[4*coord_min[0]+1, n] = xopt[4*coord_min[-1]+1] + vis[0].xyoffset[0]
-        trial_results[4*coord_min[0]+2, n] = xopt[4*coord_min[-1]+2] + vis[0].xyoffset[1]
+        
+        trial_results[4*coord_min[0]+1, n] = cos(roll_angle) * xopt[4*coord_min[-1]+1] + sin(roll_angle) * xopt[4*coord_min[-1]+2] + vis[0].xyoffset[0]
+        trial_results[4*coord_min[0]+2, n] = -sin(roll_angle) * xopt[4*coord_min[-1]+1] + cos(roll_angle) * xopt[4*coord_min[-1]+2] + vis[0].xyoffset[1]
+                
         trial_results[4*coord_min[0]+3, n] = xopt[4*coord_min[-1]+3]
 
         matrix_dist_circle_norows = matrix_dist_circle
@@ -454,11 +462,13 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
             endelse
 
             trial_results[4*coord_min[0], n]   = xopt[4*coord_min[1]]
-            trial_results[4*coord_min[0]+1, n] = xopt[4*coord_min[1]+1] + vis[0].xyoffset[0]
-            trial_results[4*coord_min[0]+2, n] = xopt[4*coord_min[1]+2] + vis[0].xyoffset[1]
+            
+            trial_results[4*coord_min[0]+1, n] = cos(roll_angle) * xopt[4*coord_min[1]+1] + sin(roll_angle) * xopt[4*coord_min[1]+2] + vis[0].xyoffset[0]
+            trial_results[4*coord_min[0]+2, n] = -sin(roll_angle) * xopt[4*coord_min[1]+1] + cos(roll_angle) * xopt[4*coord_min[1]+2] + vis[0].xyoffset[1]            
+            
             trial_results[4*coord_min[0]+3, n] = xopt[4*coord_min[1]+3]
           endfor
-        endif
+        endif      
       endif
 
 
@@ -468,7 +478,7 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         matrix_dist_ellipse  = fltarr(n_ellipse, n_ellipse)
         for i=0,n_ellipse-1 do begin
           for j=0,n_ellipse-1 do begin
-            d_i_j = sqrt((xopt[n_circle*4+6*i+1] + vis[0].xyoffset[0] - srcstr[n_circle+j].srcx )^2. + (xopt[n_circle*4+6*i+2] + vis[0].xyoffset[1] - srcstr[n_circle+j].srcy )^2.)
+            d_i_j = sqrt((cos(roll_angle) * xopt[n_circle*4+6*i+1] + sin(roll_angle) * xopt[n_circle*4+6*i+2] + vis[0].xyoffset[0] - srcstr[n_circle+j].srcx )^2. + (-sin(roll_angle) * xopt[n_circle*4+6*i+1] + cos(roll_angle) * xopt[n_circle*4+6*i+2] + vis[0].xyoffset[1] - srcstr[n_circle+j].srcy )^2.)
             matrix_dist_ellipse[j,i] = d_i_j
           endfor
         endfor
@@ -480,8 +490,10 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         eccen = SQRT(1 - EXP(-2*ecmsr))
 
         trial_results[4*n_circle+6*coord_min[0], n]   = xopt[n_circle*4+6*coord_min[-1]]
-        trial_results[4*n_circle+6*coord_min[0]+1, n] = xopt[n_circle*4+6*coord_min[-1]+1] + vis[0].xyoffset[0]
-        trial_results[4*n_circle+6*coord_min[0]+2, n] = xopt[n_circle*4+6*coord_min[-1]+2] + vis[0].xyoffset[1]
+        
+        trial_results[4*n_circle+6*coord_min[0]+1, n] = cos(roll_angle) * xopt[n_circle*4+6*coord_min[-1]+1] + sin(roll_angle) * xopt[n_circle*4+6*coord_min[-1]+2] + vis[0].xyoffset[0]
+        trial_results[4*n_circle+6*coord_min[0]+2, n] = -sin(roll_angle) * xopt[n_circle*4+6*coord_min[-1]+1] + cos(roll_angle) * xopt[n_circle*4+6*coord_min[-1]+2] + vis[0].xyoffset[1]
+        
         trial_results[4*n_circle+6*coord_min[0]+3, n] = xopt[n_circle*4+6*coord_min[-1]+3] / (1-eccen^2)^0.25
         trial_results[4*n_circle+6*coord_min[0]+4, n] = xopt[n_circle*4+6*coord_min[-1]+3] * (1-eccen^2)^0.25
 
@@ -513,6 +525,10 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
             trial_results[4*n_circle+6*coord_min[0], n]   = xopt[n_circle*4+6*coord_min[1]]
             trial_results[4*n_circle+6*coord_min[0]+1, n] = xopt[n_circle*4+6*coord_min[1]+1] + vis[0].xyoffset[0]
             trial_results[4*n_circle+6*coord_min[0]+2, n] = xopt[n_circle*4+6*coord_min[1]+2] + vis[0].xyoffset[1]
+            
+            trial_results[4*n_circle+6*coord_min[0]+1, n] = cos(roll_angle) * xopt[n_circle*4+6*coord_min[1]+1] + sin(roll_angle) * xopt[n_circle*4+6*coord_min[1]+2] + vis[0].xyoffset[0]
+            trial_results[4*n_circle+6*coord_min[0]+2, n] = -sin(roll_angle) * xopt[n_circle*4+6*coord_min[1]+1] + cos(roll_angle) * xopt[n_circle*4+6*coord_min[1]+2] + vis[0].xyoffset[1]
+            
             trial_results[4*n_circle+6*coord_min[0]+3, n] = xopt[n_circle*4+6*coord_min[1]+3] / (1-eccen^2)^0.25
             trial_results[4*n_circle+6*coord_min[0]+4, n] = xopt[n_circle*4+6*coord_min[1]+3] * (1-eccen^2)^0.25
 
@@ -530,7 +546,7 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         matrix_dist_loop  = fltarr(n_loop, n_loop)
         for i=0,n_loop-1 do begin
           for j=0,n_loop-1 do begin
-            d_i_j = sqrt((xopt[n_circle*4+6*n_ellipse+7*i+1] + vis[0].xyoffset[0] - srcstr[n_circle+n_ellipse+j].srcx )^2. + (xopt[n_circle*4+6*n_ellipse+7*i+2] + vis[0].xyoffset[1] - srcstr[n_circle+n_ellipse+j].srcy )^2.)
+            d_i_j = sqrt((cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+1] + sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+2] + vis[0].xyoffset[0] - srcstr[n_circle+j].srcx )^2. + (-sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+1] + cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*i+2] + vis[0].xyoffset[1] - srcstr[n_circle+j].srcy )^2.)
             matrix_dist_loop[j,i] = d_i_j
           endfor
         endfor
@@ -538,12 +554,14 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
         loc_dist_min0 = where( matrix_dist_loop eq min(matrix_dist_loop))
         coord_min = array_indices(matrix_dist_loop eq min(matrix_dist_loop), loc_dist_min0[0])
 
-        ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]*4+4]^2 + xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]*4+5]^2))
+        ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+4]^2 + xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+5]^2))
         eccen = SQRT(1 - EXP(-2*ecmsr))
 
         trial_results[4*n_circle+6*n_ellipse+7*coord_min[0], n]   = xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]]
-        trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+1, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+1] + vis[0].xyoffset[0]
-        trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+2, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+2] + vis[0].xyoffset[1]
+
+        trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+1, n] = cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+1] + sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+2] + vis[0].xyoffset[0]
+        trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+2, n] =  -sin(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+1] + cos(roll_angle) * xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+2] + vis[0].xyoffset[1]
+        
         trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+3, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+3] / (1-eccen^2)^0.25
         trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+4, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[-1]+3] * (1-eccen^2)^0.25
 
@@ -577,12 +595,14 @@ function vis_fwdfit_pso, configuration, vis, srcin, $
               coord_min_short = array_indices(matrix_dist_loop_norows eq min(matrix_dist_loop_norows), loc_dist_min_short)
             endelse
 
-            ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*coord_min[1]*4+4]^2 + xopt[n_circle*4+6*n_ellipse+7*coord_min[1]*4+5]^2))
+            ecmsr = REFORM(SQRT(xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+4]^2 + xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+5]^2))
             eccen = SQRT(1 - EXP(-2*ecmsr))
 
             trial_results[4*n_circle+6*n_ellipse+7*coord_min[0], n]   = xopt[n_circle*4+6*n_ellipse+7*coord_min[1]]
-            trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+1, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+1] + vis[0].xyoffset[0]
-            trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+2, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+2] + vis[0].xyoffset[1]
+            
+            trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+1, n] = cos(roll_angle) * xopt[4*n_circle+6*n_ellipse+7*coord_min[0]+1] + sin(roll_angle) * xopt[4*n_circle+6*n_ellipse+7*coord_min[0]+2] + vis[0].xyoffset[0]
+            trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+2, n] =  -sin(roll_angle) * xopt[4*n_circle+6*n_ellipse+7*coord_min[0]+1] + cos(roll_angle) * xopt[4*n_circle+6*n_ellipse+7*coord_min[0]+2] + vis[0].xyoffset[1]          
+            
             trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+3, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+3] / (1-eccen^2)^0.25
             trial_results[4*n_circle+6*n_ellipse+7*coord_min[0]+4, n] = xopt[n_circle*4+6*n_ellipse+7*coord_min[1]+3] * (1-eccen^2)^0.25
 

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_circle_struct_define.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_circle_struct_define.pro
@@ -1,4 +1,4 @@
-function vis_fwdfit_pso_circle_struct_define, vis, $
+function vis_fwdfit_pso_circle_struct_define, vis, dummy0, $
                     param_opt_circle=param_opt_circle, lower_bound_circle=lower_bound_circle, upper_bound_circle=upper_bound_circle
    
   ;Internal routine used by vis_fwdfit_pso that returns a structure that defines one component of a Gaussian circular source.
@@ -8,8 +8,8 @@ function vis_fwdfit_pso_circle_struct_define, vis, $
   phi= max(abs(vis.obsvis)) ;estimate_flux
 
   default, param_opt_circle, {param_flux: 'fit', param_x: 'fit', param_y:'fit', param_fwhm: 'fit'}
-  default, lower_bound_circle, {l_b_flux: 0.1*phi, l_b_x: -100., l_b_y: -100., l_b_fwhm: 1.}
-  default, upper_bound_circle, {u_b_flux: 1.5*phi, u_b_x: 100., u_b_y: 100., u_b_fwhm: 100.}
+  default, lower_bound_circle, {l_b_flux: 0.1*phi, l_b_x: dummy0[0]-100., l_b_y: dummy0[1]-100., l_b_fwhm: 1.}
+  default, upper_bound_circle, {u_b_flux: 1.5*phi, u_b_x: dummy0[0]+100., u_b_y: dummy0[1]+100., u_b_fwhm: +100.}
 
   circle_struct = {    type: 'circle', $
                        param_opt: param_opt_circle, $

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_circle_struct_define.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_circle_struct_define.pro
@@ -1,4 +1,4 @@
-function vis_fwdfit_pso_circle_struct_define, vis, dummy0, $
+function vis_fwdfit_pso_circle_struct_define, vis, flare_loc_HPC, $
                     param_opt_circle=param_opt_circle, lower_bound_circle=lower_bound_circle, upper_bound_circle=upper_bound_circle
    
   ;Internal routine used by vis_fwdfit_pso that returns a structure that defines one component of a Gaussian circular source.
@@ -8,8 +8,8 @@ function vis_fwdfit_pso_circle_struct_define, vis, dummy0, $
   phi= max(abs(vis.obsvis)) ;estimate_flux
 
   default, param_opt_circle, {param_flux: 'fit', param_x: 'fit', param_y:'fit', param_fwhm: 'fit'}
-  default, lower_bound_circle, {l_b_flux: 0.1*phi, l_b_x: dummy0[0]-100., l_b_y: dummy0[1]-100., l_b_fwhm: 1.}
-  default, upper_bound_circle, {u_b_flux: 1.5*phi, u_b_x: dummy0[0]+100., u_b_y: dummy0[1]+100., u_b_fwhm: +100.}
+  default, lower_bound_circle, {l_b_flux: 0.1*phi, l_b_x: flare_loc_HPC[0]-100., l_b_y: flare_loc_HPC[1]-100., l_b_fwhm: 1.}
+  default, upper_bound_circle, {u_b_flux: 1.5*phi, u_b_x: flare_loc_HPC[0]+100., u_b_y: flare_loc_HPC[1]+100., u_b_fwhm: +100.}
 
   circle_struct = {    type: 'circle', $
                        param_opt: param_opt_circle, $

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_ellipse_struct_define.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_ellipse_struct_define.pro
@@ -1,4 +1,4 @@
-function vis_fwdfit_pso_ellipse_struct_define, vis, $
+function vis_fwdfit_pso_ellipse_struct_define, vis, dummy0, $
                     param_opt_ellipse=param_opt_ellipse, lower_bound_ellipse=lower_bound_ellipse, upper_bound_ellipse=upper_bound_ellipse
   
   ;Internal routine used by vis_fwdfit_pso that returns a structure that defines one component of a Gaussian elliptical source.
@@ -8,8 +8,8 @@ function vis_fwdfit_pso_ellipse_struct_define, vis, $
   phi= max(abs(vis.obsvis)) ;estimate_flux
     
   default, param_opt_ellipse, {param_flux: 'fit', param_x: 'fit', param_y:'fit', param_fwhm_max: 'fit', param_fwhm_min: 'fit', param_alpha: 'fit'}
-  default, lower_bound_ellipse, {l_b_flux: 0.1*phi, l_b_x: -100., l_b_y: -100., l_b_fwhm: 1., l_b_eccos: -5., l_b_ecsin: 0.}
-  default, upper_bound_ellipse,  {u_b_flux: 1.5*phi, u_b_x: 100., u_b_y: 100., u_b_fwhm: 100., u_b_eccos: 5., u_b_ecsin: 1.}
+  default, lower_bound_ellipse, {l_b_flux: 0.1*phi, l_b_x: dummy0[0]-100., l_b_y: dummy0[1]-100., l_b_fwhm: 1., l_b_eccos: -5., l_b_ecsin: 0.}
+  default, upper_bound_ellipse, {u_b_flux: 1.5*phi, u_b_x: dummy0[0]+100., u_b_y: dummy0[1]+100., u_b_fwhm: 100., u_b_eccos: 5., u_b_ecsin: 1.}
   
   
   ellipse_struct = {  type:'ellipse', $

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_loop_struct_define.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_loop_struct_define.pro
@@ -1,4 +1,4 @@
-function vis_fwdfit_pso_loop_struct_define, vis, $
+function vis_fwdfit_pso_loop_struct_define, vis, dummy0, $
                     param_opt_loop=param_opt_loop, lower_bound_loop=lower_bound_loop, upper_bound_loop=upper_bound_loop
   
   ;Internal routine used by vis_fwdfit_pso that returns a structure that defines one component of a single curved elliptical gaussian.
@@ -8,9 +8,9 @@ function vis_fwdfit_pso_loop_struct_define, vis, $
   phi= max(abs(vis.obsvis)) ;estimate_flux
   
   default, param_opt_loop, {param_flux: 'fit', param_x: 'fit', param_y:'fit', param_fwhm_max: 'fit', param_fwhm_min: 'fit', param_alpha: 'fit', param_loopangle:'fit'}
-  default, lower_bound_loop, {l_b_flux: 0.1*phi, l_b_x: -100., l_b_y: -100., l_b_fwhm: 1., l_b_eccos: -5., l_b_ecsin: 0., l_b_loopangle: -180.}
-  default, upper_bound_loop, {u_b_flux: 1.5*phi, u_b_x: 100., u_b_y: 100., u_b_fwhm: 100., u_b_eccos: 5., u_b_ecsin: 1., u_b_loopangle: 180.}
-  
+  default, lower_bound_loop, {l_b_flux: 0.1*phi, l_b_x: dummy0[0]-100., l_b_y: dummy0[1]-100., l_b_fwhm: 1., l_b_eccos: -5., l_b_ecsin: 0., l_b_loopangle: -180.}
+  default, upper_bound_loop, {u_b_flux: 1.5*phi, u_b_x: dummy0[0]+100., u_b_y: dummy0[1]+100., u_b_fwhm: 100., u_b_eccos: 5., u_b_ecsin: 1., u_b_loopangle: 180.}
+ 
   loop_struct = {  type:'loop', $
                    param_opt: param_opt_loop, $
                    lower_bound: lower_bound_loop, $

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_multiple_src_create.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_multiple_src_create.pro
@@ -24,30 +24,31 @@
 ;                                                                param_opt, lower_bound and upper_bound
 
 
-FUNCTION VIS_FWDFIT_PSO_MULTIPLE_SRC_CREATE, vis, configuration, aux_data = aux_data
+FUNCTION VIS_FWDFIT_PSO_MULTIPLE_SRC_CREATE, vis, configuration, flare_loc_HPC
 
-if vis[0].type eq 'stx_visibility' then begin
-  dummy0 = stx_hpc2stx_coord(vis[0].xyoffset, aux_data, /inverse)
-endif else begin
-  dummy0 = [0.,0.];vis[0].xyoffset
-endelse
+;if vis[0].type eq 'stx_visibility' then begin
+;  dummy0 = stx_hpc2stx_coord(vis[0].xyoffset, aux_data, /inverse)
+;endif else begin
+;  dummy0 = [0.,0.];vis[0].xyoffset
+;endelse
+
 
   loc_circle  = where(configuration eq 'circle', n_circle)>0 
   loc_ellipse = where(configuration eq 'ellipse', n_ellipse)>0
   loc_loop    = where(configuration eq 'loop', n_loop)>0
   
   if n_circle gt 0 then begin
-    src_circle = vis_fwdfit_pso_circle_struct_define(vis, dummy0)
+    src_circle = vis_fwdfit_pso_circle_struct_define(vis, flare_loc_HPC)
     src_circle = cmreplicate(src_circle, n_circle)
   endif
   
   if n_ellipse gt 0 then begin
-    src_ellipse = vis_fwdfit_pso_ellipse_struct_define(vis, dummy0)
+    src_ellipse = vis_fwdfit_pso_ellipse_struct_define(vis, flare_loc_HPC)
     src_ellipse = cmreplicate(src_ellipse, n_ellipse)
   endif
   
   if n_loop gt 0 then begin
-    src_loop = vis_fwdfit_pso_loop_struct_define(vis, dummy0)
+    src_loop = vis_fwdfit_pso_loop_struct_define(vis, flare_loc_HPC)
     src_loop = cmreplicate(src_loop, n_loop)
   endif
   

--- a/stix/idl/processing/imaging/vis_fwdfit_pso_multiple_src_create.pro
+++ b/stix/idl/processing/imaging/vis_fwdfit_pso_multiple_src_create.pro
@@ -15,31 +15,39 @@
 ;                    - 'circle' : Gaussian circular source
 ;                    - 'ellipse': Gaussian elliptical source
 ;                    - 'loop'   : single curved elliptical gaussian
-;
+;   aux_data: structure containing the average values of SAS solution, apparent radius of the Sun, roll angle, pitch, yaw, L0 and B0
+;             computed over a considered time range
+;             
 ; Example: if configuration=['circle', 'ellipse', 'circle'], srcin has two main fields: srcin.circle and srcin.ellipse
 ;                                                                srcin.circle has two main fields srcin.circle[0] and srcin.circle[1]
 ;                                                                both srcin.circle[0], srcin.circle[1] and srcin.ellipse have 3 fields:
 ;                                                                param_opt, lower_bound and upper_bound
 
 
-FUNCTION VIS_FWDFIT_PSO_MULTIPLE_SRC_CREATE, vis, configuration
+FUNCTION VIS_FWDFIT_PSO_MULTIPLE_SRC_CREATE, vis, configuration, aux_data = aux_data
+
+if vis[0].type eq 'stx_visibility' then begin
+  dummy0 = stx_hpc2stx_coord(vis[0].xyoffset, aux_data, /inverse)
+endif else begin
+  dummy0 = [0.,0.];vis[0].xyoffset
+endelse
 
   loc_circle  = where(configuration eq 'circle', n_circle)>0 
   loc_ellipse = where(configuration eq 'ellipse', n_ellipse)>0
   loc_loop    = where(configuration eq 'loop', n_loop)>0
   
   if n_circle gt 0 then begin
-    src_circle = vis_fwdfit_pso_circle_struct_define(vis)
+    src_circle = vis_fwdfit_pso_circle_struct_define(vis, dummy0)
     src_circle = cmreplicate(src_circle, n_circle)
   endif
   
   if n_ellipse gt 0 then begin
-    src_ellipse = vis_fwdfit_pso_ellipse_struct_define(vis)
+    src_ellipse = vis_fwdfit_pso_ellipse_struct_define(vis, dummy0)
     src_ellipse = cmreplicate(src_ellipse, n_ellipse)
   endif
   
   if n_loop gt 0 then begin
-    src_loop = vis_fwdfit_pso_loop_struct_define(vis)
+    src_loop = vis_fwdfit_pso_loop_struct_define(vis, dummy0)
     src_loop = cmreplicate(src_loop, n_loop)
   endif
   


### PR DESCRIPTION
Closes #198 

Changes made to solve the bug: when selecting upper and lower bounds of the x and y coordinates, the sources were placed in the wrong position. Rotation of 90 degrees with respect to SolarOrbiter and the roll_angle is now taken into account.

- stx_vis_fwdfit_pso: convertion from HPC to STIX coordinate frame (if the (x,y) location is set by the user);  upper and lower bound transformation from the Solar Orbiter coordinate frame to the STIX coordinate frame;
- vis_fwdfit_pso and vis_fwdfit_func_pso: roll angle is taken into account. It is also taken into account that the coordinates of the position are searched in a rectangle centered on (0,0).