### PR TITLE
Use user's local directory if default not writable - addresses issue #234

### DIFF
--- a/stix/idl/demo/stx_imaging_demo.pro
+++ b/stix/idl/demo/stx_imaging_demo.pro
@@ -18,14 +18,17 @@
 ;   23-august-2022, Massa P., made compatible with the up-to-date imaging sofwtare
 ;   11-september-2023 - ECMD (Graz), allow user to specify output directory
 ;   11-january-2024 - Massa P., use 'stx_get_science_fits_file' and 'stx_get_ephemeris_file' to download fits files
-;   11-november-2024 - Massa P., change "" to '' for string definition. 
+;   11-november-2024 - Massa P., change "" to '' for string definition.
+;   2025-01-10, F. Schuller (AIP): add a test that out_dir exists and is writable
 ;-
 
 ;;******************************** LOAD DATA - June 7 2020, 21:41 UT ********************************
 
 ; Folder in which the files downloaded for this demonstration are stored
  default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'imaging', /d)
-
+ tst = file_test(out_dir, /dir, /write)
+ if ~tst then out_dir = app_user_dir('ssw', 'Solar Software', 'stix', 'STIX Ground Software', '', 1)
+ 
 ; UID of the science fits file to be dowloaded from the website
 uid_sci_file = '1178428688'
 path_sci_file = stx_get_science_fits_file(uid_sci_file, out_dir=out_dir)

--- a/stix/idl/demo/stx_imaging_demo.pro
+++ b/stix/idl/demo/stx_imaging_demo.pro
@@ -27,7 +27,11 @@
 ; Folder in which the files downloaded for this demonstration are stored
  default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'imaging', /d)
  tst = file_test(out_dir, /dir, /write)
- if ~tst then out_dir = app_user_dir('ssw', 'Solar Software', 'stix', 'STIX Ground Software', '', 1)
+ if ~tst then begin
+  ssw_dir = strjoin([home_dir(),'.ssw', 'so', 'stix'], path_sep())
+  if ~file_test(ssw_dir, /dir, /write) then file_mkdir, ssw_dir
+  out_dir = ssw_dir
+ endif
  
 ; UID of the science fits file to be dowloaded from the website
 uid_sci_file = '1178428688'

--- a/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
+++ b/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
@@ -45,12 +45,14 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   default, out_dir, concat_dir( getenv('STX_DEMO_DATA'),'ospex', /d)
 
   ;if the OSPEX demo database folder is not present then create it
-  if ~file_test(out_dir, /directory) then begin
-    file_mkdir, out_dir
-  endif
-  ; But if it's not writable, then use a local, user-specific directory
-  tst = file_test(out_dir, /dir, /write)
-  if ~tst then out_dir = app_user_dir('ssw', 'Solar Software', 'ospex', 'OSPEX - Object Spectral Analysis Executive', '', 1)
+  if ~file_test(out_dir, /directory) then $
+    if file_test(getenv('STX_DEMO_DATA'), /dir, /write) then file_mkdir, out_dir $
+    else begin
+      ; But if it's not writable, then use a local, user-specific directory
+      ssw_dir = strjoin([home_dir(),'.ssw', 'so', 'stix'], path_sep())
+      if ~file_test(ssw_dir, /dir, /write) then file_mkdir, ssw_dir
+      out_dir = ssw_dir
+    endelse
 
   ;As an example a spectrogram file for a flare on 8th February 2022 is used
   uid_spec_file = '2202080003'
@@ -99,10 +101,10 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   print, ' '
   print, 'Press SPACE to continue'
   print, ' '
-
+  pause
+  
   ;The fit interval selected for this demonstration covers one minute over the first non-thermal peak
   spex_fit_time_interval = ['8-Feb-2022 21:38:59.937', '8-Feb-2022 21:40:00.437']
-
 
 
   ;*************************************** FLARE LOCATION **************************************

--- a/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
+++ b/stix/idl/demo/stx_ospex_spectroscopy_demo.pro
@@ -30,6 +30,7 @@
 ;   23-Oct-2023 - ECMD (Graz), include specification of flare location
 ;   05-Feb-2024 - ECMD (Graz), files now downloaded using UID and stx_get_science_fits_file.pro
 ;   11-Nov-2024 - Massa P. (FHNW), changed "" with '' for string definition
+;   2025-01-10, F. Schuller (AIP): add a test that out_dir exists and is writable
 ;
 ;-
 pro stx_ospex_spectroscopy_demo, out_dir = out_dir
@@ -47,6 +48,9 @@ pro stx_ospex_spectroscopy_demo, out_dir = out_dir
   if ~file_test(out_dir, /directory) then begin
     file_mkdir, out_dir
   endif
+  ; But if it's not writable, then use a local, user-specific directory
+  tst = file_test(out_dir, /dir, /write)
+  if ~tst then out_dir = app_user_dir('ssw', 'Solar Software', 'ospex', 'OSPEX - Object Spectral Analysis Executive', '', 1)
 
   ;As an example a spectrogram file for a flare on 8th February 2022 is used
   uid_spec_file = '2202080003'

--- a/stix/idl/processing/spectrogram/stx_check_config_files.pro
+++ b/stix/idl/processing/spectrogram/stx_check_config_files.pro
@@ -162,26 +162,42 @@ pro stx_check_config_files, directory, verbose = verbose
       online_version = ourl->get(/string)
       
      if find_version_file ne '' then begin
-        readcol, find_version_file, current_version, format = 'a', /silent
-       if current_version eq online_version then print,'STIX Configuration files are already up to date ' + online_version else run_update =  1 
-      endif else run_update =  1 
+       readcol, find_version_file, current_version, format = 'a', /silent
+       if current_version eq online_version then print,'STIX Configuration files are already up to date ' + online_version $
+          else run_update =  1
+     endif else run_update =  1
 
     if run_update then begin
       ; test if user has write permission to that directory, otherwise use local directory
       tst = file_test(directory, /dir, /write)
       if ~tst then begin
-        directory = app_user_dir('ssw', 'Solar Software', 'stix', 'STIX Ground Software', '', 1)
+        ssw_dir = strjoin([home_dir(),'.ssw', 'so', 'stix'], path_sep())
+        if ~file_test(ssw_dir, /dir, /write) then file_mkdir, ssw_dir
+        directory = ssw_dir
         ; also update envirnoment variable, so that other STIX-GSW procedures can find the files
         ; that will now be updated
         setenv, 'STX_DET='+directory
+        ; also update path to version file
+        version_file = concat_dir(directory, 'stix_conf_version.txt')
+        ; check again whether local version of config files is already up-to-date
+        find_version_file = loc_file(version_file)
+        if find_version_file ne '' then begin
+          readcol, find_version_file, current_version, format = 'a', /silent
+          if current_version eq online_version then begin
+            print,'STIX Configuration files are already up to date ' + online_version
+            run_update = 0
+          endif
+        endif
       endif
 
-      stx_update_elut, directory, verbose = verbose
-      stx_update_echan, directory, verbose = verbose
-
-      ;update version file
-      str2file, online_version, version_file
+      if run_update then begin
+        message, "Downloading elut_table files...", /continue
+        stx_update_elut, directory, verbose = verbose
+        message, "Downloading ScienceEnergyChannels files...", /continue
+        stx_update_echan, directory, verbose = verbose
+        ;update version file
+        str2file, online_version, version_file
+      endif
     endif
   endelse
-
 end

--- a/stix/idl/processing/spectrogram/stx_check_config_files.pro
+++ b/stix/idl/processing/spectrogram/stx_check_config_files.pro
@@ -138,6 +138,7 @@ end
 ; :history:
 ;    31-Aug-2023 - ECMD (Graz), initial release
 ;    22-Jan-2024 - Use Dominic Zarro's <idlneturl2> __define in place of out of box IDL idlneturl
+;    2025-01-10, F. Schuller (AIP): test if STX_DET directory is writable, otherwise use local user dir
 ;
 ;-
 pro stx_check_config_files, directory, verbose = verbose
@@ -164,8 +165,16 @@ pro stx_check_config_files, directory, verbose = verbose
         readcol, find_version_file, current_version, format = 'a', /silent
        if current_version eq online_version then print,'STIX Configuration files are already up to date ' + online_version else run_update =  1 
       endif else run_update =  1 
-      
+
     if run_update then begin
+      ; test if user has write permission to that directory, otherwise use local directory
+      tst = file_test(directory, /dir, /write)
+      if ~tst then begin
+        directory = app_user_dir('ssw', 'Solar Software', 'stix', 'STIX Ground Software', '', 1)
+        ; also update envirnoment variable, so that other STIX-GSW procedures can find the files
+        ; that will now be updated
+        setenv, 'STX_DET='+directory
+      endif
 
       stx_update_elut, directory, verbose = verbose
       stx_update_echan, directory, verbose = verbose


### PR DESCRIPTION
Added tests in demo scripts and in stx_check_config_files to use a local dir. if the user does not have write permission to folders under $SSW.