### PR TITLE
Additions and corrections in FITS header generated by stx_map2fits

### DIFF
--- a/stix/idl/io/stx_map2fits.pro
+++ b/stix/idl/io/stx_map2fits.pro
@@ -14,9 +14,7 @@
 ;               PATH_SCI_FILE = path to the L1 file used for reconstructing the STIX image
 ;
 ; Keywords    : PATH_BKG_FILE = path to the L1 BKG file included for the reconstruction of the STIX image
-;               ERR = error string
-;               BYTE_SCALE = byte scale data
-;
+;               ERR ;
 ; Comments    : Based on map2fits in sswidl, but adapted for STIX images
 ; History     : 05-04-2022, Hualin Xiao (hualin.xiao@fhnw.ch)
 ;                - copied map2fits from ssw and add more keywords to the 
@@ -111,6 +109,10 @@
     alg = map[i].id
     algo_used = alg.remove(-2,-1)
     
+    ;; Number of counts
+    cnts_total = map[i].OBS_VIS[0].TOT_COUNTS
+    cnts_bkg = map[i].OBS_VIS[0].TOT_COUNTS_BKG
+    
     ;; Extract pointing information
     aux_data = map[i].aux_data
     stx_x = aux_data.stx_pointing[0]
@@ -177,9 +179,9 @@
     fxaddpar, header, 'RSUN_OBS', rsun_arc, '[arcsec] Apparent photospheric solar radius'
     fxaddpar, header, 'RSUN_ARC', rsun_arc, '[arcsec] Apparent photospheric solar radius'
     fxaddpar, header, 'HGLT_OBS', b0_ang, '[deg] s/c heliographic latitude (B0 angle)'
-    fxaddpar, header, 'HGLN_OBS', sxpar(this_header,'HGLN_OBS'), '[deg] s/c heliographic longitude'
+    fxaddpar, header, 'HGLN_OBS', l0_ang, '[deg] s/c heliographic longitude (L0 angle)'
     fxaddpar, header, 'CRLT_OBS', b0_ang, '[deg] s/c Carrington latitude (B0 angle)'
-    fxaddpar, header, 'CRLN_OBS', l0_ang, '[deg] s/c Carrington longitude (L0 angle)'
+    fxaddpar, header, 'CRLN_OBS', sxpar(this_header,'CRLN_OBS'), '[deg] s/c Carrington longitude'
     fxaddpar, header, 'DSUN_OBS', sxpar(this_header,'DSUN_OBS'), '[m] s/c distance from Sun'
     fxaddpar, header, 'HEEX_OBS', sxpar(this_header,'HEEX_OBS'), '[m] s/c Heliocentric Earth Ecliptic X'
     fxaddpar, header, 'HEEY_OBS', sxpar(this_header,'HEEY_OBS'), '[m] s/c Heliocentric Earth Ecliptic Y'
@@ -226,6 +228,10 @@
     fxaddpar,header,'CUNIT2','arcsec  ','units along axis 2'
     fxaddpar,header,'CROTACN1',map[i].roll_center[0],'[arcsec] Rotation x center'
     fxaddpar,header,'CROTACN1',map[i].roll_center[1],'[arcsec] Rotation y center'
+
+;-- also write the total number of counts and background counts
+    fxaddpar,header,'CNTS_TOT', cnts_total, 'Total number of counts'
+    fxaddpar,header,'CNTS_BKG', cnts_bkg, 'Number of counts subtracted as background'
 
 ;-- add in user-specified properties
 

--- a/stix/idl/processing/imaging/stx_vis_clean.pro
+++ b/stix/idl/processing/imaging/stx_vis_clean.pro
@@ -100,6 +100,7 @@
 ; 05-jun-2022  Paolo: added 'aux_data' input
 ; 05-oct-2022  Paolo: updated for using 'stx_make_map'
 ; 02-jan-2023  Paolo: 'image_dim' casted as integer and fixed bug in the iterative plot.
+; 23-jun-2026  Frederic: minor changes when opening windows for plotting
 ;-
 
 
@@ -237,10 +238,12 @@ function stx_vis_clean, vis, aux_data, niter = niter, image_dim = image_dim_in, 
       ;contour, /over, cleaned_map_iter, col=2, thick=2, levels = interpol( minmax( cleaned_map_iter ), 5)
       ;cleaned_map_iter = convol( clean_map, clean_beam, /norm, /center, /edge_zero)
       cleaned_map_iter = convolve(clean_map, clean_beam/total(clean_beam))
-      if first_time eq 1 then begin
-        window,2,xsize=5*this_disp,ysize=this_disp
-        first_time=0
-      endif
+;      if first_time eq 1 then begin
+;        window,2,xsize=5*this_disp,ysize=this_disp
+;        first_time=0
+;      endif
+      device, Window_State=win_state
+      if win_state[7] then wset, 7 else window, 7, xsize=5*this_disp, ysize=this_disp
       erase
       this_dmap0=dmap0
       cc_indices=array_indices(this_dmap0,clean_box[iz]); indices of the clean component location
@@ -363,7 +366,8 @@ function stx_vis_clean, vis, aux_data, niter = niter, image_dim = image_dim_in, 
 
 
   if keyword_set(plot) then begin
-    window,6,xsize=5*this_disp,ysize=2*this_disp
+    device, Window_State=win_state
+    if win_state[6] then wset, 6 else window, 6, xsize=5*this_disp, ysize=2*this_disp
     cleanplot, /silent
     !p.multi=[0,3,1]
     chs2=2.


### PR DESCRIPTION
- add CNTS_TOT and CNTS_BKG in FITS header; this solves issue #222 
- correct Carrington longitude / heliographic longitude in FITS header
- minor changes when opening windows for plotting in stx_vis_clean